### PR TITLE
openalex skill v0.2: integrate API guide for LLMs

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,9 @@
 # LOG
 
+## 2026-02-24
+
+- `openalex` SKILL.md v0.2: added filter syntax (OR/NOT/ranges), batch pipe lookup, two-step entity lookup, `group_by`/`sample`/`seed` params, `per-page=200` default, error handling with backoff, endpoint costs table
+
 ## 2026-02-15
 
 - Saved reference documents in `docs/`: [testing-agent-skills-with-evals.md](docs/testing-agent-skills-with-evals.md) and [agent-skills-specification.md](docs/agent-skills-specification.md)


### PR DESCRIPTION
## Summary

- Add filter syntax table (OR `|`, NOT `!`, comparison operators, ranges)
- Add Batch Lookup section (pipe operator for up to 50 IDs in one request)
- Add Two-Step Entity Lookup pattern (name → ID → filter)
- Add `group_by=`, `sample=`, `seed=` to Query Blocks
- Set `per-page=200` as recommended default (was 25)
- Add Error Handling section with HTTP codes and exponential backoff
- Add Endpoint Costs table ($0.0001 list, $0.001 search, $0.01 PDF)
- Update Common Pitfalls with new anti-patterns

## Test plan

- [x] Verify filter syntax examples parse correctly with the API
- [x] Verify batch pipe lookup example returns expected results
- [x] Verify two-step entity lookup example works end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)