### PR TITLE
fix(openalex): prevent API key exposure in output

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,9 @@
 # LOG
 
+## 2026-04-24
+
+- `openalex`: strengthen API key security — added prominent SECURITY callout at top of SKILL.md; expanded Common Pitfalls rule to cover all output contexts (text responses, echoed commands, logs), not just verification
+
 ## 2026-03-03
 
 - `evals/openalex`: add `run_evals.sh` — runs prompts via `claude -p`, saves outputs to `runs/YYYY-MM-DD/`, auto-checks 4 pitfall patterns (relevance_sort, title.search scope, multi-line curl, API key printed)

--- a/skills/openalex/SKILL.md
+++ b/skills/openalex/SKILL.md
@@ -15,6 +15,8 @@ Use this skill to run reliable OpenAlex API workflows from shell.
 
 > **IMPORTANT:** Always write `curl` commands on a **single line**. Multi-line `\` continuation breaks argument parsing in agent environments and will cause errors.
 
+> **SECURITY:** Never expose the actual value of `OPENALEX_API_KEY` anywhere — not in text responses, not in echoed commands, not in logs. Always reference it as `$OPENALEX_API_KEY`. If the key appears in any output, stop immediately and do not repeat it.
+
 ## Definition of Done
 
 A task is complete when:
@@ -213,7 +215,7 @@ Use `select=` and `per-page=200` to minimize request count.
 - Always write `curl` commands on a single line — multi-line `\` continuation breaks argument parsing in agent environments.
 - `title.search` is NOT a valid standalone parameter — always pass it inside `filter=`: `filter=title.search:"your query"`.
 - Always include `api_key=$OPENALEX_API_KEY` in every request.
-- Never print or echo `$OPENALEX_API_KEY` to verify it is set — use `[[ -n "${OPENALEX_API_KEY:-}" ]]` instead.
+- **Never expose the actual key value** — not in text output, not in echoed commands, not in any form. Always use the variable reference `$OPENALEX_API_KEY`. To verify it is set: `[[ -n "${OPENALEX_API_KEY:-}" ]] && echo "key is set" || echo "ERROR: OPENALEX_API_KEY not set"`.
 
 ## Resources
 

--- a/skills/openalex/SKILL.md
+++ b/skills/openalex/SKILL.md
@@ -215,7 +215,8 @@ Use `select=` and `per-page=200` to minimize request count.
 - Always write `curl` commands on a single line — multi-line `\` continuation breaks argument parsing in agent environments.
 - `title.search` is NOT a valid standalone parameter — always pass it inside `filter=`: `filter=title.search:"your query"`.
 - Always include `api_key=$OPENALEX_API_KEY` in every request.
-- **Never expose the actual key value** — not in text output, not in echoed commands, not in any form. Always use the variable reference `$OPENALEX_API_KEY`. To verify it is set: `[[ -n "${OPENALEX_API_KEY:-}" ]] && echo "key is set" || echo "ERROR: OPENALEX_API_KEY not set"`.
+- **Never expose the actual key value** — not in text output, not in echoed commands, not in logs, and not in any other form. Always use the variable reference `$OPENALEX_API_KEY`.
+  - To verify it is set: `[[ -n "${OPENALEX_API_KEY:-}" ]] && echo "key is set" || echo "ERROR: OPENALEX_API_KEY not set"`.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Add `SECURITY` callout at top of `SKILL.md` — prohibits exposing the actual `OPENALEX_API_KEY` value in any output context (text responses, echoed commands, logs)
- Strengthen Common Pitfalls entry to cover all output contexts, not just the verification step

## Test plan

- [ ] Verify the SECURITY callout appears immediately after the IMPORTANT callout in `SKILL.md`
- [ ] Verify the updated Common Pitfalls entry uses bold and covers all output contexts
- [ ] Confirm existing scripts (`openalex_query.sh`, `openalex_download_pdf.sh`) already use `$OPENALEX_API_KEY` reference only (no change needed)