### PR TITLE
feat(cup-cig): add cig-fetch.sh script for full CIG detail

### DIFF
--- a/skills/cup-cig/SKILL.md
+++ b/skills/cup-cig/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cup-cig
 description: Guide users monitoring Italian public procurement to extract detailed information from lists of CUP (Codice Unico di Progetto) and CIG (Codice Identificativo Gara). Use when the user wants to look up project metadata, financial status, or tender details for Italian public contracts.
-compatibility: Requires curl, jq, bash, internet access. OpenCUP API requires OPENCUP_API_CLIENT_ID and OPENCUP_API_CLIENT_SECRET environment variables. scripts/cig-fetch.sh requires agent-browser.
+compatibility: Requires curl, jq, bash, internet access. OpenCUP API requires OPENCUP_API_CLIENT_ID and OPENCUP_API_CLIENT_SECRET environment variables. scripts/cig-fetch.sh requires agent-browser and timeout (GNU coreutils; macOS: brew install coreutils).
 license: CC BY-SA 4.0 (Creative Commons Attribution-ShareAlike 4.0 International)
 metadata:
   version: "0.1"
@@ -31,13 +31,12 @@ User has a CUP
        └─ ANAC BDNCP bulk (authoritative CUP↔CIG join)
 
 User has a CIG
+  ├─ Full detail (participants, awards, subcontracts, financials) — any CIG type?
+  │    └─ ANAC dettaglio-cig → scripts/cig-fetch.sh (requires agent-browser)
   ├─ Starts with Z (e.g. Z063947806)?
-  │    └─ Below-threshold direct award → ANAC BDNCP bulk only
-  └─ Alphanumeric (e.g. 8874674CA7)?
-       ├─ Basic tender list / award outcomes?
-       │    └─ SCP-MIT API
-       └─ Full detail (participants, awards, subcontracts, financials)?
-            └─ ANAC dettaglio-cig → scripts/cig-fetch.sh (requires agent-browser)
+  │    └─ Below-threshold direct award → ANAC BDNCP bulk (no live API)
+  └─ Alphanumeric (e.g. 8874674CA7) — basic tender list / outcomes?
+       └─ SCP-MIT API
 ```
 
 ---

--- a/skills/cup-cig/SKILL.md
+++ b/skills/cup-cig/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cup-cig
 description: Guide users monitoring Italian public procurement to extract detailed information from lists of CUP (Codice Unico di Progetto) and CIG (Codice Identificativo Gara). Use when the user wants to look up project metadata, financial status, or tender details for Italian public contracts.
-compatibility: Requires curl, jq, bash, internet access. OpenCUP API requires OPENCUP_API_CLIENT_ID and OPENCUP_API_CLIENT_SECRET environment variables.
+compatibility: Requires curl, jq, bash, internet access. OpenCUP API requires OPENCUP_API_CLIENT_ID and OPENCUP_API_CLIENT_SECRET environment variables. scripts/cig-fetch.sh requires agent-browser.
 license: CC BY-SA 4.0 (Creative Commons Attribution-ShareAlike 4.0 International)
 metadata:
   version: "0.1"
@@ -34,7 +34,10 @@ User has a CIG
   ├─ Starts with Z (e.g. Z063947806)?
   │    └─ Below-threshold direct award → ANAC BDNCP bulk only
   └─ Alphanumeric (e.g. 8874674CA7)?
-       └─ SCP-MIT API (published tenders)
+       ├─ Basic tender list / award outcomes?
+       │    └─ SCP-MIT API
+       └─ Full detail (participants, awards, subcontracts, financials)?
+            └─ ANAC dettaglio-cig → scripts/cig-fetch.sh (requires agent-browser)
 ```
 
 ---
@@ -161,6 +164,41 @@ duckdb -c "SELECT * FROM read_csv_auto('cup.csv', HEADER=TRUE) WHERE cig = 'Z063
 
 - Find CIG(s) associated with a CUP: filter `cup` column.
 - Find details of a Z-prefix CIG (direct award): filter `cig` column.
+
+---
+
+## Source 5 — ANAC dettaglio-cig: Full CIG Detail
+
+**Portal:** `https://dettaglio-cig.anticorruzione.it/cig/{CIG}`
+**Method:** Browser automation via `scripts/cig-fetch.sh`
+**Requires:** `agent-browser`, `jq`
+**Coverage:** All CIG types (Z-prefix and alphanumeric). Returns 20+ sections.
+
+The payload is far richer than SCP-MIT: includes `bando`, `stazioneAppaltante`,
+`partecipanti`, `incaricati`, `aggiudicazione`, `quadroEconomico`, `subappalti`,
+`varianti`, `categorieOpera`, `pubblicazioni`, and more.
+
+### Fetch full detail for a single CIG
+
+```bash
+bash scripts/cig-fetch.sh 8874674CA7
+# → ./8874674CA7.json
+```
+
+```bash
+bash scripts/cig-fetch.sh 8874674CA7 /tmp
+# → /tmp/8874674CA7.json
+```
+
+### Troubleshooting
+
+If the script fails with `Invalid response: EOF`:
+
+```bash
+agent-browser close
+```
+
+Then rerun the script.
 
 ---
 

--- a/skills/cup-cig/scripts/cig-fetch.sh
+++ b/skills/cup-cig/scripts/cig-fetch.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Scarica il JSON completo di un CIG dal portale ANAC dettaglio-cig.
+# Gist: https://gist.github.com/aborruso/183e93419b5d3528af69a6617e97a3f1
+# Richiede: agent-browser (https://github.com/vercel-labs/agent-browser), jq
+set -euo pipefail
+
+if ! command -v agent-browser >/dev/null 2>&1; then
+  echo "Errore: 'agent-browser' non installato." >&2
+  echo "Info e installazione: https://github.com/vercel-labs/agent-browser" >&2
+  exit 127
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Errore: 'jq' non installato." >&2
+  exit 127
+fi
+
+if [ $# -lt 1 ]; then
+  echo "Uso: $0 <CIG> [output-dir]" >&2
+  exit 1
+fi
+
+CIG="$1"
+OUTDIR="${2:-.}"
+URL="https://dettaglio-cig.anticorruzione.it/cig/${CIG}"
+OUT="${OUTDIR%/}/${CIG}.json"
+
+mkdir -p "$OUTDIR"
+
+# Sessione dedicata per non interferire con altre istanze agent-browser
+export AGENT_BROWSER_SESSION="cig-fetch"
+
+# Chiudi eventuali sessioni rimaste appese da run precedenti
+agent-browser close >/dev/null 2>&1 || true
+sleep 1
+
+# Timeout globale: oltre HARD_TIMEOUT secondi si considera fallito
+HARD_TIMEOUT="${CIG_FETCH_TIMEOUT:-15}"
+
+run() {
+  # Esegue un comando agent-browser con timeout per step; fallisce se scade.
+  local step_timeout="$1"; shift
+  if ! timeout "$step_timeout" "$@" >/dev/null 2>&1; then
+    echo "Errore: step scaduto (${step_timeout}s): $*" >&2
+    agent-browser close >/dev/null 2>&1 || true
+    exit 4
+  fi
+}
+
+# Avvia il timer complessivo come watchdog in background
+(
+  sleep "$HARD_TIMEOUT"
+  kill -TERM $$ 2>/dev/null
+) &
+WATCHDOG=$!
+trap 'kill $WATCHDOG 2>/dev/null || true; agent-browser close >/dev/null 2>&1 || true' EXIT
+trap 'echo "Errore: timeout globale ${HARD_TIMEOUT}s superato" >&2; exit 5' TERM
+
+run 8 agent-browser open "$URL"
+run 6 agent-browser wait --text "I accept that the form entries"
+
+run 4 agent-browser eval "(async () => {
+  for (let i = 0; i < 20; i++) {
+    const cb = document.querySelector('input[type=checkbox]');
+    if (cb) { cb.click(); return 'clicked'; }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  return 'not-found';
+})()"
+
+run 3 agent-browser eval "(() => {
+  const orig = URL.createObjectURL;
+  URL.createObjectURL = function(blob) {
+    if (blob instanceof Blob) blob.text().then(t => window.__capturedJSON = t);
+    return orig.call(this, blob);
+  };
+  return 'hooked';
+})()"
+
+# Click "Cerca" via JS (il finder role-button si blocca su questa SPA)
+run 3 agent-browser eval "(() => {
+  const b = Array.from(document.querySelectorAll('button')).find(x => x.innerText.trim() === 'Cerca');
+  if (!b) return 'no-cerca';
+  b.click();
+  return 'clicked';
+})()"
+
+run 8 agent-browser wait --text "Informazioni Gara"
+
+# Click "Esporta in JSON" via JS (match parziale su "JSON")
+run 3 agent-browser eval "(() => {
+  const b = Array.from(document.querySelectorAll('button')).find(x => /JSON/i.test(x.innerText));
+  if (!b) return 'no-json';
+  b.click();
+  return 'clicked';
+})()"
+
+# Attendi che il blob JSON venga catturato (entro il timeout residuo)
+RAW='""'
+for i in $(seq 1 10); do
+  sleep 1
+  RAW=$(agent-browser eval "window.__capturedJSON || ''" --json 2>/dev/null || echo '""')
+  if [ "$(printf '%s' "$RAW" | wc -c)" -gt 20 ]; then
+    break
+  fi
+done
+
+kill $WATCHDOG 2>/dev/null || true
+agent-browser close >/dev/null 2>&1 || true
+
+if [ -z "${RAW:-}" ] || [ "$RAW" = '""' ]; then
+  echo "Errore: JSON non catturato per $CIG" >&2
+  exit 2
+fi
+
+printf '%s' "$RAW" | jq -r '.data.result' > "$OUT"
+
+if ! jq -e . "$OUT" >/dev/null 2>&1; then
+  echo "Errore: output non è JSON valido ($OUT)" >&2
+  exit 3
+fi
+
+echo "OK: $OUT ($(wc -c <"$OUT") byte)"

--- a/skills/cup-cig/scripts/cig-fetch.sh
+++ b/skills/cup-cig/scripts/cig-fetch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Scarica il JSON completo di un CIG dal portale ANAC dettaglio-cig.
 # Gist: https://gist.github.com/aborruso/183e93419b5d3528af69a6617e97a3f1
-# Richiede: agent-browser (https://github.com/vercel-labs/agent-browser), jq
+# Richiede: agent-browser (https://github.com/vercel-labs/agent-browser), jq, timeout (GNU coreutils)
 set -euo pipefail
 
 if ! command -v agent-browser >/dev/null 2>&1; then
@@ -12,6 +12,11 @@ fi
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "Errore: 'jq' non installato." >&2
+  exit 127
+fi
+
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "Errore: 'timeout' non trovato (GNU coreutils richiesto; su macOS: brew install coreutils)." >&2
   exit 127
 fi
 
@@ -27,10 +32,10 @@ OUT="${OUTDIR%/}/${CIG}.json"
 
 mkdir -p "$OUTDIR"
 
-# Sessione dedicata per non interferire con altre istanze agent-browser
-export AGENT_BROWSER_SESSION="cig-fetch"
+# Sessione univoca per evitare race condition tra run concorrenti
+export AGENT_BROWSER_SESSION="cig-fetch-${CIG}-$$"
 
-# Chiudi eventuali sessioni rimaste appese da run precedenti
+# Chiudi eventuali sessioni rimaste appese da run precedenti con lo stesso nome
 agent-browser close >/dev/null 2>&1 || true
 sleep 1
 
@@ -115,8 +120,8 @@ fi
 
 printf '%s' "$RAW" | jq -r '.data.result' > "$OUT"
 
-if ! jq -e . "$OUT" >/dev/null 2>&1; then
-  echo "Errore: output non è JSON valido ($OUT)" >&2
+if ! jq 'if type == "object" or type == "array" then true else error end' "$OUT" >/dev/null 2>&1; then
+  echo "Errore: output non è un oggetto/array JSON valido ($OUT)" >&2
   exit 3
 fi
 


### PR DESCRIPTION
## Summary

- Add `scripts/cig-fetch.sh`: downloads the full CIG JSON from `dettaglio-cig.anticorruzione.it` via `agent-browser` automation
- The payload includes 20+ sections (bando, partecipanti, aggiudicazione, quadroEconomico, subappalti, varianti, categorieOpera, pubblicazioni, ...) — far richer than SCP-MIT
- Update `SKILL.md`: decision tree extended with full-detail path, new Source 5 section, compatibility field updated
- Script already includes `agent-browser` and `jq` installation checks (exit 127 if missing)

Source: https://gist.github.com/aborruso/183e93419b5d3528af69a6617e97a3f1

## Test plan

- [ ] Run `bash scripts/cig-fetch.sh 8874674CA7` and verify output JSON is valid
- [ ] Run with missing `agent-browser` and verify exit 127 error message
- [ ] Verify decision tree in SKILL.md routes correctly to Source 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)