### PR TITLE
fix(cup-cig): increase wait timeout for Informazioni Gara to 30s

### DIFF
--- a/skills/cup-cig/scripts/cig-fetch.sh
+++ b/skills/cup-cig/scripts/cig-fetch.sh
@@ -90,7 +90,7 @@ run 3 agent-browser eval "(() => {
   return 'clicked';
 })()"
 
-run 8 agent-browser wait --text "Informazioni Gara"
+run 30 agent-browser wait --text "Informazioni Gara"
 
 # Click "Esporta in JSON" via JS (match parziale su "JSON")
 run 3 agent-browser eval "(() => {


### PR DESCRIPTION
## Summary

- `run 8 agent-browser wait --text "Informazioni Gara"` → `run 30`
- The ANAC portal backend can be slow; 8s caused false timeouts even when the service was responding

🤖 Generated with [Claude Code](https://claude.com/claude-code)