### PR TITLE
difensore-civico-ti-scrivo: add HVD references and Category G

### DIFF
--- a/skills/difensore-civico-ti-scrivo/SKILL.md
+++ b/skills/difensore-civico-ti-scrivo/SKILL.md
@@ -8,7 +8,7 @@ description: >
   write to the Difensore Civico per il Digitale; complain about open data violations,
   non-machine-readable public data, inaccessible PA portals, missing or restrictive licenses
   on public data, captchas blocking automated access, unanswered data reuse requests (D.Lgs.
-  36/2006 art. 5), failure to publish mandatory High Value Datasets (HVD, Reg. UE 2023/138),
+  36/2006 art. 5), failure to publish mandatory High Value Datasets (HVD, Reg. (UE) 2023/138),
   or a prior DCD complaint that got no response. Trigger even if the user does not name the
   skill — any Italian digital-rights complaint targeting a PA is a candidate.
 ---

--- a/skills/difensore-civico-ti-scrivo/SKILL.md
+++ b/skills/difensore-civico-ti-scrivo/SKILL.md
@@ -8,8 +8,9 @@ description: >
   write to the Difensore Civico per il Digitale; complain about open data violations,
   non-machine-readable public data, inaccessible PA portals, missing or restrictive licenses
   on public data, captchas blocking automated access, unanswered data reuse requests (D.Lgs.
-  36/2006 art. 5), or a prior DCD complaint that got no response. Trigger even if the user
-  does not name the skill — any Italian digital-rights complaint targeting a PA is a candidate.
+  36/2006 art. 5), failure to publish mandatory High Value Datasets (HVD, Reg. UE 2023/138),
+  or a prior DCD complaint that got no response. Trigger even if the user does not name the
+  skill — any Italian digital-rights complaint targeting a PA is a candidate.
 ---
 
 # difensore-civico-ti-scrivo
@@ -24,6 +25,11 @@ the DCD's main function. If the user describes an accessibility complaint (recla
 dichiarazione di accessibilità, L. 4/2004 — Funzione B), redirect them: the correct channel
 is *exclusively* the link on the reported entity's own website, not AGID. Do not draft a
 Funzione B complaint through this skill.
+
+**Covered norms.** In addition to the CAD, this skill covers D.Lgs. 36/2006 (open data and
+reuse) and EU regulations directly applicable in Italy — in particular **Reg. (UE) 2023/138**
+(High Value Datasets — HVD), which requires publication of six dataset categories via
+machine-readable API; obligations have been enforceable since 9 June 2024.
 
 **One complaint per PA.** If multiple administrations are involved, produce one *segnalazione*
 per administration.

--- a/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
+++ b/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
@@ -259,3 +259,72 @@ inadempienza da parte di [ENTE].
 **Remedy to request:** "accerti lo stato della precedente segnalazione (prot. [N.]) e, ove
 [ENTE] non abbia ancora ottemperato, eserciti i poteri di cui all'art. 18-bis del CAD,
 compresi, se del caso, i poteri sanzionatori ivi previsti."
+
+---
+
+## Category G — Mancata pubblicazione di dataset ad alto valore (HVD)
+
+**When:** A PA responsible for one or more High Value Dataset (HVD) categories defined in
+Reg. (UE) 2023/138 has not published the required datasets — i.e., the datasets are entirely
+absent from the national open data catalog (dati.gov.it) and/or not accessible via API, past
+the 9 June 2024 deadline.
+
+Distinct from Category A (wrong format) and Category B (access barriers): here the data
+does not exist at all in the catalog.
+
+**Additional questions to ask the user:**
+- Which HVD category is affected? (geospaziale / osservazione della terra e ambiente /
+  meteorologica / statistica / imprese e proprietà societaria / mobilità)
+- Which specific PA is responsible? Note: multiple PAs may hold obligations per category.
+  For "imprese": Camere di Commercio / Unioncamere; for "mobilità": MIT + Regioni.
+  Draft one *segnalazione* per PA.
+- Have you verified on dati.gov.it filtering by the `hvd_category` field? What result?
+- Have you cross-checked on data.europa.eu for Italian datasets in this category?
+
+**Articles to cite:** Reg. (UE) 2023/138 artt. 3 co. 1 and 4 co. 2–3; D.Lgs. 36/2006 artt.
+12-bis co. 1, 9 co. 2, and 12 ult. co.
+
+**Adaptable legal language (Italian):**
+
+```
+[ENTE] non ha reso disponibile alcuna serie di dati rientrante nella categoria
+"[CATEGORIA HVD]" prevista dall'allegato del Regolamento di esecuzione (UE) 2023/138 della
+Commissione, del 21 dicembre 2022 [1], né sul catalogo nazionale dei dati aperti
+(dati.gov.it) né tramite API accessibili pubblicamente.
+
+Tale inadempienza perdura da oltre [N MESI] rispetto alla scadenza del 9 giugno 2024, data
+dalla quale il Regolamento è applicabile ai sensi del suo articolo 6 (pubblicato in GUUE
+L 19/43 del 20 gennaio 2023, entrato in vigore il 9 febbraio 2023, applicabile dal 9 giugno
+2024). L'assenza è stata verificata direttamente su dati.gov.it tramite filtro sul campo
+hvd_category e confermata su data.europa.eu.
+
+Ciò contrasta con:
+
+- l'art. 3, paragrafo 1, del Reg. (UE) 2023/138 [1], che impone agli enti pubblici che
+  detengono serie di dati di elevato valore di garantirne la messa a disposizione "in
+  formati leggibili meccanicamente tramite API corrispondenti alle ragionevoli esigenze dei
+  riutilizzatori";
+- l'art. 4, paragrafo 2, del medesimo Regolamento [1], che estende l'obbligo alle serie di
+  dati esistenti create prima della data di applicazione;
+- l'art. 4, paragrafo 3, del medesimo Regolamento [1], che impone licenza CC0 o CC BY 4.0;
+- l'art. 12-bis, comma 1, del D.Lgs. 24 gennaio 2006, n. 36 [2], che recepisce
+  nell'ordinamento nazionale tali obblighi, disponendo che le serie di dati di elevato
+  valore siano rese disponibili gratuitamente, leggibili meccanicamente, fornite mediante
+  API e come download in blocco;
+- l'art. 9, comma 2, del medesimo D.Lgs. 36/2006 [3], che impone l'utilizzo del catalogo
+  nazionale dei dati aperti gestito da AgID (dati.gov.it) come "punto di accesso unico alle
+  serie di dati";
+- l'art. 12, ultimo comma, del D.Lgs. 36/2006 [4], che prevede esplicitamente il ricorso
+  al difensore civico per il digitale in caso di violazione delle disposizioni del decreto.
+
+Il Regolamento (UE) 2023/138 è direttamente applicabile negli Stati membri ai sensi
+dell'art. 288, secondo comma, del TFUE, senza necessità di recepimento nazionale.
+[ENTE] rientra nell'ambito soggettivo di applicazione ai sensi [dell'art. 1, comma 2, del
+D.Lgs. 36/2006 / dell'art. 2, comma 2, del CAD — eliminare la variante non applicabile].
+```
+
+**Remedy to request:** "pubblichi le serie di dati ad alto valore della categoria
+"[CATEGORIA HVD]" in formati leggibili meccanicamente tramite API pubblica con licenza CC0
+o CC BY 4.0, le renda disponibili come download in blocco ove applicabile, e le cataloghi
+su dati.gov.it con il campo hvd_category valorizzato, nel rispetto del Reg. (UE) 2023/138
+e dell'art. 12-bis del D.Lgs. 36/2006."

--- a/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
+++ b/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
@@ -266,7 +266,7 @@ compresi, se del caso, i poteri sanzionatori ivi previsti."
 
 **When:** A PA responsible for one or more High Value Dataset (HVD) categories defined in
 Reg. (UE) 2023/138 has not published the required datasets — i.e., the datasets are entirely
-absent from the national open data catalog (dati.gov.it) and/or not accessible via API, past
+absent from the national open data catalog (dati.gov.it) and not accessible via API, past
 the 9 June 2024 deadline.
 
 Distinct from Category A (wrong format) and Category B (access barriers): here the data
@@ -281,16 +281,16 @@ does not exist at all in the catalog.
 - Have you verified on dati.gov.it filtering by the `hvd_category` field? What result?
 - Have you cross-checked on data.europa.eu for Italian datasets in this category?
 
-**Articles to cite:** Reg. (UE) 2023/138 artt. 3 co. 1 and 4 co. 2–3; D.Lgs. 36/2006 artt.
-12-bis co. 1, 9 co. 2, and 12 ult. co.
+**Articles to cite:** Reg. (UE) 2023/138 artt. 3 par. 1 e 4 parr. 2–3; D.Lgs. 36/2006 artt.
+12-bis co. 1, 9 co. 2 e 12 ult. co.
 
 **Adaptable legal language (Italian):**
 
 ```
 [ENTE] non ha reso disponibile alcuna serie di dati rientrante nella categoria
 "[CATEGORIA HVD]" prevista dall'allegato del Regolamento di esecuzione (UE) 2023/138 della
-Commissione, del 21 dicembre 2022 [1], né sul catalogo nazionale dei dati aperti
-(dati.gov.it) né tramite API accessibili pubblicamente.
+Commissione, del 21 dicembre 2022, né sul catalogo nazionale dei dati aperti (dati.gov.it)
+né tramite API accessibili pubblicamente.
 
 Tale inadempienza perdura da oltre [N MESI] rispetto alla scadenza del 9 giugno 2024, data
 dalla quale il Regolamento è applicabile ai sensi del suo articolo 6 (pubblicato in GUUE
@@ -300,21 +300,21 @@ hvd_category e confermata su data.europa.eu.
 
 Ciò contrasta con:
 
-- l'art. 3, paragrafo 1, del Reg. (UE) 2023/138 [1], che impone agli enti pubblici che
+- l'art. 3, paragrafo 1, del Reg. (UE) 2023/138, che impone agli enti pubblici che
   detengono serie di dati di elevato valore di garantirne la messa a disposizione "in
   formati leggibili meccanicamente tramite API corrispondenti alle ragionevoli esigenze dei
   riutilizzatori";
-- l'art. 4, paragrafo 2, del medesimo Regolamento [1], che estende l'obbligo alle serie di
+- l'art. 4, paragrafo 2, del medesimo Regolamento, che estende l'obbligo alle serie di
   dati esistenti create prima della data di applicazione;
-- l'art. 4, paragrafo 3, del medesimo Regolamento [1], che impone licenza CC0 o CC BY 4.0;
-- l'art. 12-bis, comma 1, del D.Lgs. 24 gennaio 2006, n. 36 [2], che recepisce
+- l'art. 4, paragrafo 3, del medesimo Regolamento, che impone licenza CC0 o CC BY 4.0;
+- l'art. 12-bis, comma 1, del D.Lgs. 24 gennaio 2006, n. 36, che recepisce
   nell'ordinamento nazionale tali obblighi, disponendo che le serie di dati di elevato
   valore siano rese disponibili gratuitamente, leggibili meccanicamente, fornite mediante
   API e come download in blocco;
-- l'art. 9, comma 2, del medesimo D.Lgs. 36/2006 [3], che impone l'utilizzo del catalogo
+- l'art. 9, comma 2, del medesimo D.Lgs. 36/2006, che impone l'utilizzo del catalogo
   nazionale dei dati aperti gestito da AgID (dati.gov.it) come "punto di accesso unico alle
   serie di dati";
-- l'art. 12, ultimo comma, del D.Lgs. 36/2006 [4], che prevede esplicitamente il ricorso
+- l'art. 12, ultimo comma, del D.Lgs. 36/2006, che prevede esplicitamente il ricorso
   al difensore civico per il digitale in caso di violazione delle disposizioni del decreto.
 
 Il Regolamento (UE) 2023/138 è direttamente applicabile negli Stati membri ai sensi

--- a/skills/difensore-civico-ti-scrivo/references/normativa.md
+++ b/skills/difensore-civico-ti-scrivo/references/normativa.md
@@ -152,6 +152,84 @@ procedimento entro 90 giorni, la segnalazione si intende archiviata senza comuni
 
 ---
 
+## D.Lgs. 24 gennaio 2006, n. 36 — Articoli aggiuntivi
+
+### Art. 9, comma 2 — Obbligo di catalogazione su dati.gov.it
+
+> "Per la ricerca di dati in formato aperto, le pubbliche amministrazioni, gli organismi di
+> diritto pubblico, le imprese pubbliche e le imprese private di cui all'articolo 1, comma
+> 2-quater, utilizzano il catalogo nazionale dei dati aperti gestito dall'Agenzia per
+> l'Italia digitale, come punto di accesso unico alle serie di dati, ad eccezione dei set di
+> dati territoriali che sono disponibili anche nel Repertorio Nazionale dei dati Territoriali."
+
+URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2006-01-24;36~art9>
+
+---
+
+### Art. 12, ultimo comma — Competenza del DCD per violazioni open data
+
+> "In caso di violazione delle disposizioni introdotte dalle Linee guida, il soggetto
+> interessato può rivolgersi al difensore civico per il digitale di cui all'articolo 17,
+> comma 1-quater, del Codice dell'amministrazione digitale e si applicano le sanzioni
+> previste dall'articolo 18-bis, comma 5, dello stesso Codice."
+
+URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2006-01-24;36~art12>
+
+---
+
+### Art. 12-bis — Serie specifiche di dati di elevato valore (HVD)
+
+> **Co. 1** — "Alle specifiche serie di dati di elevato valore individuate dalla Commissione
+> europea ai sensi dell'articolo 14, paragrafo 1, della direttiva UE n. 1024/2019 all'interno
+> delle categorie previste dall'articolo 13 e dall'allegato I della medesima direttiva, si
+> applicano le seguenti disposizioni:
+> a) sono rese disponibili gratuitamente [...];
+> b) sono rese leggibili meccanicamente;
+> c) sono fornite mediante API;
+> d) sono fornite come download in blocco, se del caso."
+
+URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2006-01-24;36~art12bis>
+
+---
+
+## Reg. di esecuzione (UE) 2023/138 — High Value Datasets (HVD)
+
+Direttamente applicabile negli Stati membri ai sensi dell'art. 288, co. 2, TFUE.
+Pubblicato in GUUE L 19/43 del 20 gennaio 2023. Entrato in vigore il 9 febbraio 2023.
+**Applicabile dal 9 giugno 2024** (16 mesi dall'entrata in vigore, ai sensi dell'art. 6).
+
+URL testo integrale: <https://eur-lex.europa.eu/eli/reg_impl/2023/138/oj>
+
+### Art. 3, comma 1 — Obbligo di pubblicazione via API per tutte le categorie HVD
+
+> "Gli enti pubblici che detengono serie di dati di elevato valore elencate nell'allegato
+> garantiscono che le serie di dati descritte o cui si fa riferimento nell'allegato siano
+> messe a disposizione in formati leggibili meccanicamente tramite API corrispondenti alle
+> ragionevoli esigenze dei riutilizzatori. Se indicato nell'allegato, le serie di dati sono
+> rese disponibili anche come download in blocco."
+
+### Art. 4, commi 2 e 3 — Ambito (anche dati preesistenti) e licenza
+
+> **Co. 2** — "Al fine di agevolare la disponibilità di serie di dati per il riutilizzo su
+> periodi di tempo prolungati, gli obblighi imposti dal presente regolamento si applicano
+> anche alle serie di dati di elevato valore esistenti, leggibili meccanicamente, che sono
+> state create prima della data di applicazione del presente regolamento."
+
+> **Co. 3** — "Le serie di dati di elevato valore sono rese disponibili per il riutilizzo
+> alle condizioni della licenza Creative Commons Public Domain Dedication (CC0) o, in
+> alternativa, della licenza Creative Commons BY 4.0, o di qualsiasi licenza aperta
+> equivalente o meno restrittiva [...]"
+
+### Art. 6 — Entrata in vigore e data di applicazione
+
+> "Il presente regolamento entra in vigore il ventesimo giorno successivo alla pubblicazione
+> nella Gazzetta ufficiale dell'Unione europea. Esso si applica a decorrere da 16 mesi dopo
+> la sua entrata in vigore."
+
+Calcolo: pubblicato 20 gen 2023 → in vigore 9 feb 2023 → **applicabile dal 9 giugno 2024**.
+
+---
+
 ## DPR 28 dicembre 2000, n. 445 — Dichiarazione di responsabilità
 
 Standard declaration to include in every complaint:

--- a/skills/difensore-civico-ti-scrivo/references/normativa.md
+++ b/skills/difensore-civico-ti-scrivo/references/normativa.md
@@ -200,7 +200,7 @@ Pubblicato in GUUE L 19/43 del 20 gennaio 2023. Entrato in vigore il 9 febbraio 
 
 URL testo integrale: <https://eur-lex.europa.eu/eli/reg_impl/2023/138/oj>
 
-### Art. 3, comma 1 — Obbligo di pubblicazione via API per tutte le categorie HVD
+### Art. 3, paragrafo 1 — Obbligo di pubblicazione via API per tutte le categorie HVD
 
 > "Gli enti pubblici che detengono serie di dati di elevato valore elencate nell'allegato
 > garantiscono che le serie di dati descritte o cui si fa riferimento nell'allegato siano
@@ -208,14 +208,14 @@ URL testo integrale: <https://eur-lex.europa.eu/eli/reg_impl/2023/138/oj>
 > ragionevoli esigenze dei riutilizzatori. Se indicato nell'allegato, le serie di dati sono
 > rese disponibili anche come download in blocco."
 
-### Art. 4, commi 2 e 3 — Ambito (anche dati preesistenti) e licenza
+### Art. 4, paragrafi 2 e 3 — Ambito (anche dati preesistenti) e licenza
 
-> **Co. 2** — "Al fine di agevolare la disponibilità di serie di dati per il riutilizzo su
+> **Par. 2** — "Al fine di agevolare la disponibilità di serie di dati per il riutilizzo su
 > periodi di tempo prolungati, gli obblighi imposti dal presente regolamento si applicano
 > anche alle serie di dati di elevato valore esistenti, leggibili meccanicamente, che sono
 > state create prima della data di applicazione del presente regolamento."
 
-> **Co. 3** — "Le serie di dati di elevato valore sono rese disponibili per il riutilizzo
+> **Par. 3** — "Le serie di dati di elevato valore sono rese disponibili per il riutilizzo
 > alle condizioni della licenza Creative Commons Public Domain Dedication (CC0) o, in
 > alternativa, della licenza Creative Commons BY 4.0, o di qualsiasi licenza aperta
 > equivalente o meno restrittiva [...]"


### PR DESCRIPTION
## Summary

- Add Reg. (UE) 2023/138 (High Value Datasets) to the skill's covered norms: scope paragraph in `SKILL.md` + trigger in the description frontmatter
- Add legal references in `normativa.md`: D.Lgs. 36/2006 artt. 9 co. 2, 12 (last paragraph), 12-bis; Reg. (UE) 2023/138 artt. 3, 4, 6 with deadline calculation (9 June 2024)
- Add **Category G** in `categorie-violazioni.md` — mancata pubblicazione HVD: when to use, additional interview questions, articles to cite, adaptable Italian legal language, remedy to request. Explicitly distinct from Category A (wrong format) and B (access barriers): here the data does not exist at all in the catalog

## Context

Motivated by discussion ondata/attivita#112: Italy has not published HVD datasets for the "imprese e proprietà societaria" and "mobilità" categories, 23+ months past the June 2024 deadline. A complaint to the Difensore Civico per il Digitale is being drafted using this skill.

## Test plan

- [ ] Trigger skill on an HVD non-publication case and verify Category G is selected
- [ ] Confirm legal citations match the normativa.md sources
- [ ] Check subject line stays ≤ 100 characters in generated complaint

🤖 Generated with [Claude Code](https://claude.com/claude-code)