### PR TITLE
difensore-civico: failure modes, DCD procedure, skill quality rubric

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,26 @@ fix broken curl example in query-recipes
 3. Copy evals template: `cp -r evals/_template/ evals/<skill-name>/` and fill in the three files.
 4. Open a PR.
 
+### Writing good skill content
+
+Use the [`skill-creator`](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+skill to draft, test, and iterate on new skills. It covers the full loop: draft → run test
+prompts → review outputs → improve → optimize the `description` field for triggering accuracy.
+
+When writing the skill body, prioritize these three content dimensions — empirically validated
+as the strongest predictors of downstream skill utility (Huang et al. 2026,
+[arXiv:2605.23899](https://arxiv.org/abs/2605.23899)):
+
+| Dimension | What it means |
+|---|---|
+| **Failure Mechanism Encoding** | Name specific failure modes with executable remedies, not generic warnings |
+| **Actionable Specificity** | Concrete, executable instructions — not process-level advice like "be careful" |
+| **High-Risk Action Blacklist** | Explicit list of actions the agent must never do in this domain |
+
+Note: skill *format* (ordered list, bullets, prose) has no measurable effect on utility —
+only the content matters. Optimizing for clarity or completeness without grounding in these
+three dimensions does not improve performance and may hurt it.
+
 ## Developer notes
 
 ### Local development with open-data-quality scripts

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@ The following documents are not part of this repository and are not covered by t
 | Document | Author | Link |
 |---|---|---|
 | The Complete Guide to Building Skills for Claude | Anthropic | [PDF](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) |
+| From Raw Experience to Skill Consumption: A Systematic Study of Model-Generated Agent Skills | Huang et al., Fudan / Microsoft Research, 2026 | [arXiv](https://arxiv.org/abs/2605.23899) · [local](from-raw-experience-to-skill-consumption-2026.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,12 @@ The following documents are not part of this repository and are not covered by t
 | Document | Author | Link |
 |---|---|---|
 | The Complete Guide to Building Skills for Claude | Anthropic | [PDF](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) |
-| From Raw Experience to Skill Consumption: A Systematic Study of Model-Generated Agent Skills | Huang et al., Fudan / Microsoft Research, 2026 | [arXiv](https://arxiv.org/abs/2605.23899) · [local](from-raw-experience-to-skill-consumption-2026.md) |
+| From Raw Experience to Skill Consumption: A Systematic Study of Model-Generated Agent Skills | Huang et al., Fudan / Microsoft Research, 2026 | [arXiv](https://arxiv.org/abs/2605.23899) |
+
+## Repository notes on third-party resources
+
+These are repo-authored summaries and annotations of external works. Covered by the project license.
+
+| Document | Notes |
+|---|---|
+| [from-raw-experience-to-skill-consumption-2026.md](from-raw-experience-to-skill-consumption-2026.md) | Summary of Huang et al. 2026 — key findings and validated rubric for skill writing |

--- a/docs/from-raw-experience-to-skill-consumption-2026.md
+++ b/docs/from-raw-experience-to-skill-consumption-2026.md
@@ -1,0 +1,169 @@
+# From Raw Experience to Skill Consumption: A Systematic Study of Model-Generated Agent Skills
+
+**Authors:** Zisu Huang, Jingwen Xu, Yifan Yang, Ziyang Gong, Qihao Yang, Muzhao Tian, Xiaohua Wang, Changze Lv, Xuemei Gao, Qi Dai, Bei Liu, Kai Qiu, Xue Yang, Dongdong Chen, Xiaoqing Zheng, Chong Luo  
+**Affiliations:** Fudan University, Microsoft Research, Shanghai Jiao Tong University  
+**Date:** May 2026  
+**Source:** https://arxiv.org/abs/2605.23899
+
+---
+
+## Abstract
+
+Language agents increasingly improve by reusing knowledge distilled from past trajectories: _skills_—short, structured procedural artifacts—can be loaded at inference time without retraining and have become a defining mechanism for accumulating experience in modern agent stacks. In particular, _domain-level skills_ package a domain's recurring procedures into a single reusable artifact or a coordinated set of them, enabling fast adaptation to new tasks within the domain rather than per-task optimization.
+
+This paper conducts a comprehensive, utility-grounded study of model-generated, domain-level skills that analyzes all three stages of the skill lifecycle: **experience generation → skill extraction → skill consumption**. The study spans five domains, six target models, and five extractor models.
+
+---
+
+## Key Research Questions
+
+- **RQ1** Do model-generated, domain-level skills reliably benefit downstream agents across targets, extractors, and domains?
+- **RQ2** What actually drives a skill's downstream utility across the three lifecycle stages?
+- **RQ3** Can empirical findings be transformed into a concrete, drop-in improvement to skill extraction itself?
+
+---
+
+## Evaluation Framework
+
+### Skill Lifecycle
+
+**Stage 1 — Experience generation:** Target model M executes training tasks, producing an experience pool of (task, trajectory, outcome) triples with both successful and failed trajectories.
+
+**Stage 2 — Skill extraction:** Extractor E distills the pool into a skill set using a two-stage framework:
+- _Per-trajectory analysis_: each trajectory is independently processed to extract up to K success or failure patterns.
+- _Hierarchical consolidation_: pattern sets are merged in groups (configurable size G) until a single consolidated pattern set remains, then converted to schema-conformant skills via tool calls.
+
+**Stage 3 — Skill consumption:** The same target M is provided with the extracted skills (in the system prompt) and evaluated on held-out tasks.
+
+### Skill Representation
+
+Each skill follows the **Agent Skills open standard** (https://github.com/agentskills/agentskills) with fields: `name`, `description`, `body` (Markdown procedural instructions), and optional `references` and `scripts`.
+
+### Metrics
+
+**Performance delta:**  
+Δ(E, M, D) = Perf(M | skills, test) − Perf(M | test)
+
+**Extraction Efficacy (EE):** For a fixed extractor, how reliably it produces helpful skills across different target models.
+
+**Target Evolvability (TE):** For a fixed target, how much it benefits from skills extracted by different extractors.
+
+---
+
+## Main Results (RQ1)
+
+Evaluated across five domains: ALFWorld (embodied), SpreadsheetBench (productivity), SWE-bench-Verified (software engineering), SEAL-0 (web search), BFCL-v4 (tool calling).
+
+### Skills are generally beneficial, but not guaranteed
+
+- Positive gains in **75% of entries**
+- **25% negative transfer** (skills degrade performance)
+- Domain-dependent risk: SpreadsheetBench and SWE-bench lowest negative rate (13%); ALFWorld most fragile (47%)
+
+### Better executor ≠ better extractor
+
+On SpreadsheetBench, the lightweight Gemini-3.1-Flash-Lite achieves the highest EE, while GPT-5.4 ranks last despite having the strongest baseline. Skill extraction is a **distinct capability** from task execution.
+
+### Skill utility is target-dependent
+
+The same extractors can produce very different gains across targets in the same domain. Skill benefit is shaped both by extractor quality and by what the target's own experience makes extractable.
+
+---
+
+## Diving Deeper into the Lifecycle (RQ2)
+
+### Experience Generation: Success or Failure?
+
+Success/failure pool composition strongly affects skill quality:
+- **All-failure pools perform worst** — successful trajectories are essential as they provide positive procedural signals.
+- Optimal ratio is **domain-specific**: SpreadsheetBench favors success-heavy pools; ALFWorld performs best with failure-heavy pools (failed attempts reveal invalid actions and dead-end states).
+
+### Skill Extraction: What Makes a Good Skill?
+
+**Format does not matter.** Four formats tested (ordered list, unordered list, checklist, prose) — the format effect is statistically non-significant on every target (all p > 0.34). Variance is driven by **what** a skill says, not how it looks.
+
+**Textual plausibility does not predict utility.** Without evaluation criteria, an LLM judge picks the better skill only **46.4% of the time** (random). On pairs with large gaps (δ ≥ 5%), accuracy drops to **15.8%** — the skill that reads better is often the one that performs worse.
+
+**Qualitative pattern:** High-utility skills name **concrete failure mechanisms with executable remedies** (e.g., "formulas are not evaluated in headless environments; always precompute static values in Python"). Low-utility skills offer only generic process-level advice (e.g., "resolve the contract before coding").
+
+### Skill Consumption: Benefit Varies Across Targets
+
+- With the same skill, per-target gains differ sharply.
+- Skills distilled from strong-baseline experience pools consistently improve all targets.
+- Skills from weak pools cause negative transfer on some targets.
+- Skill consumption **reshapes the default policy** rather than triggering explicit skill calls.
+
+---
+
+## From Diagnosis to Intervention: Validated Rubric (RQ3)
+
+### Three Dimensions That Predict Utility
+
+Discovered through automated contrastive analysis of high-gap skill pairs. Better-rates (proportion where higher-Δ skill scores better) in parentheses:
+
+| Dimension | Description | Better-rate |
+|---|---|---|
+| **Failure Mechanism Encoding** | Names specific domain failure modes with executable remedies | 64–66% |
+| **Actionable Specificity** | Concrete, executable instructions rather than generic advice | 64–66% |
+| **High-Risk Action Blacklist** | Explicit list of actions to avoid | 64–66% |
+
+### What Does NOT Predict Utility (plausibility rubric, 7 naive dimensions)
+
+Clarity, completeness, conciseness, logical structure, formatting, tone, generality — these are what an LLM believes distinguishes good skills, but they **do not align with actual downstream performance**.
+
+### Impact of the Validated Rubric
+
+Adding the 3-dimension rubric to the extractor's system prompt:
+- Improves **all 9 evaluated cells** (+1.55 pp average)
+- Largest gains on SpreadsheetBench (+2.3 to +3.7 pp)
+
+Adding the naive 7-dimension plausibility rubric:
+- **Hurts** average performance (−0.59 pp), reducing accuracy in 6 of 9 cells
+
+### Judge Accuracy with Rubric Guidance
+
+| Condition | Overall accuracy | On hardest pairs (δ ≥ 5%) |
+|---|---|---|
+| Unguided LLM judge | 46.4% | 15.8% |
+| With validated rubric | **73.8%** | majority correct |
+
+---
+
+## Conclusion
+
+Model-generated skills are beneficial on average (75% of cases) but exhibit substantial variance and non-trivial negative transfer (25% of cases). Neither model scale nor textual plausibility reliably predicts downstream utility.
+
+Key practical takeaways:
+1. **Format is irrelevant** — focus on content.
+2. **Encode failure mechanisms** — name what goes wrong and how to fix it.
+3. **Be specific** — generic process advice provides no actionable leverage.
+4. **Include blacklists** — explicit "never do X" improves performance.
+5. **Use the validated rubric** when evaluating or generating skills; ignore plausibility-based criteria.
+
+---
+
+## Appendix: Contrastive Skill Examples
+
+### SpreadsheetBench (Δ gap = 10.3 pp)
+
+**Higher-Δ skill** (Gemini-3.1-FL, Δ = +14.7): Encodes three domain-specific failure mechanisms:
+1. Formula injection fallacy — formulas not evaluated in headless execution; always precompute static values in Python.
+2. Index-shifting errors during deletion — use reverse iteration.
+3. Dynamic addressing — never use hardcoded cell references.
+
+**Lower-Δ skill** (GPT-5.4, Δ = +4.3): Only process-level directives ("resolve the contract," "edit minimally") — reasonable but too abstract to prevent the concrete failure modes.
+
+### ALFWorld (Δ gap = 6.0 pp)
+
+**Higher-Δ skill** (Gemini-3.1-Pro, Δ = +7.5): Provides executable action patterns tailored to ALFWorld's mechanics:
+1. Deep inspection — explicitly open closed containers; don't assume visibility equals absence.
+2. Active state transformations — concrete locate-acquire-transport-invoke pipeline.
+3. Prerequisite resolution — navigate and open destinations _before_ attempting placement.
+
+**Lower-Δ skill** (GPT-5.4, Δ = +1.5): Same high-level logic ("ground the goal," "manage preconditions") but at a level of abstraction that doesn't map onto ALFWorld's action vocabulary.
+
+---
+
+## Note on Agent Skills Standard
+
+This study uses the Agent Skills open standard as its skill schema — the same format used by this repository. The skill fields (name, description, body, references, scripts) are the experimental unit throughout the paper.

--- a/skills/difensore-civico-ti-scrivo/SKILL.md
+++ b/skills/difensore-civico-ti-scrivo/SKILL.md
@@ -34,6 +34,41 @@ machine-readable API; obligations have been enforceable since 9 June 2024.
 **One complaint per PA.** If multiple administrations are involved, produce one *segnalazione*
 per administration.
 
+## Common failure modes
+
+These are the most frequent reasons a *segnalazione* fails or is dismissed. Check each before
+drafting.
+
+**Inadmissibility — complaint is not processed at all (art. 4 co. 3 Regolamento DCD)**
+- Missing sender identity (full name + email/PEC): without these the complaint is inadmissible
+  regardless of its merit. Remedy: always collect Group A in full before drafting.
+- Missing DPR 445/2000 declaration: the statutory self-certification is a formal requirement.
+  Remedy: always include the standard block; never omit it even if the user objects.
+
+**Wrong channel — complaint reaches the wrong office**
+- Accessibility complaints (L. 4/2004, Funzione B) sent here are not processed by the DCD;
+  the user loses time and may miss the correct channel. Remedy: redirect immediately (see
+  *Scope and constraints*).
+
+**Premature complaint — DCD unlikely to proceed**
+- Art. 5 D.Lgs. 36/2006 (unanswered reuse request): the DCD expects evidence that the user
+  already sent a formal reuse request to the PA and received no response or a refusal. Without
+  this prior step the complaint will likely be archived as premature. Remedy: ask Group C before
+  drafting; if no prior request exists, advise the user to send it first.
+- Prior DCD *segnalazione* unresolved: if the user already filed for the same PA and received a
+  protocol number but no outcome, the new complaint must reference that number explicitly;
+  otherwise the DCD may treat it as a duplicate and archive it.
+
+**Weak evidence — complaint cannot be acted on**
+- Vague description without URLs, dates, or observable facts: the DCD cannot invite the PA to
+  remedy what it cannot identify. Remedy: insist on at least one URL and one specific date in
+  Group B; if the user cannot provide them, note the limitation explicitly in the complaint text.
+
+**Delivery failure — no legal proof of submission**
+- Sending via ordinary email (not PEC and not the AGID web form) produces no legal proof of
+  delivery; the DCD may never acknowledge receipt. Remedy: Step 4 covers the two valid channels;
+  always remind the user before they send.
+
 ## Step 1 — Interview
 
 Collect the required information before drafting. Ask in conversational turns — not all at
@@ -167,11 +202,40 @@ render Markdown. Apply these rules strictly:
 
 After the draft, tell the user:
 
-- **Official channel:** submit via the AGID form at
-  <https://www.agid.gov.it/it/form/difensore-civico-digitale> (requires SPID or CIE login).
-  The form collects the same information as this complaint.
-- **PEC alternative:** send to `protocollo@pec.agid.gov.it`. Keep both the *ricevuta di
-  accettazione* and *ricevuta di avvenuta consegna* as proof.
+- **Recommended channel — PEC:** send to `protocollo@pec.agid.gov.it`. Keep both the
+  *ricevuta di accettazione* and *ricevuta di avvenuta consegna* as legally valid delivery
+  proof. PEC is preferred over the form because it leaves a traceable paper trail in the
+  sender's hands.
+- **Alternative — AGID web form:** <https://www.agid.gov.it/it/form/difensore-civico-digitale>
+  (requires SPID or CIE login). The form collects the same information but provides no
+  receipt to the sender.
 - The DCD has **90 days** to conclude the procedure (Regolamento art. 8). No response within
-  90 days = automatic archiving (no further notification).
+  90 days = automatic archiving (no further notification). The clock is suspended: up to 20
+  days if AgID consults internal structures; during **10–20 August** and **25 December–1
+  January**.
 - One *segnalazione* per PA. If multiple PAs are involved, send separately.
+
+## What to expect after submission
+
+Tell the user what happens next, to set realistic expectations:
+
+1. **Pre-istruttoria (art. 5 Regolamento):** The DCD reviews admissibility. If the complaint
+   is inadmissible or irricevibile (too vague, wrong channel, duplicate), it is archived
+   silently with no notification.
+
+2. **Istruttoria (art. 6):** If the complaint passes, the DCD may request information from
+   both the sender and the PA, with a 15-day peremptory deadline. Cooperate promptly.
+
+3. **Transmission to Direttore Generale (art. 18-bis CAD):** If the DCD finds the complaint
+   "non manifestamente infondata", it forwards the file to AgID's Direttore Generale, who can:
+   - assign a peremptory deadline to the PA to comply;
+   - report the violation to the PA's disciplinary office and performance evaluation body;
+   - impose a fine of **€10,000–€100,000** (art. 18-bis co. 5).
+
+4. **Realistic outcome:** In most cases the PA receives a formal invitation to comply and
+   does so within the assigned deadline. Monetary sanctions are the exception, not the rule.
+   The procedure does not give the user an enforceable right to the data — it is an
+   administrative oversight channel, not a court order.
+
+5. **No news = archived:** If 90 days pass with no communication, the complaint was archived.
+   The user can file a new complaint (Category F) if the violation persists.

--- a/skills/difensore-civico-ti-scrivo/SKILL.md
+++ b/skills/difensore-civico-ti-scrivo/SKILL.md
@@ -40,8 +40,15 @@ These are the most frequent reasons a *segnalazione* fails or is dismissed. Chec
 drafting.
 
 **Inadmissibility — complaint is not processed at all (art. 4 co. 3 Regolamento DCD)**
-- Missing sender identity (full name + email/PEC): without these the complaint is inadmissible
-  regardless of its merit. Remedy: always collect Group A in full before drafting.
+- Missing sender identity (full name and contact details): art. 4 co. 3 requires "dati
+  identificativi del segnalante"; without them the complaint is inadmissible. Remedy: always
+  collect Group A in full before drafting.
+- Missing reply PEC/email in the complaint body: the DCD sends all communications to the
+  address stated in the segnalazione (Regolamento art. 10). If the sender's PEC is not
+  included in the complaint text, official responses may be lost or delivered without legal
+  value. Remedy: always include the sender's PEC (preferred) or email explicitly in the
+  sender block, even when submitting via PEC — the transmission address and the reply
+  address must both appear in the document.
 - Missing DPR 445/2000 declaration: the statutory self-certification is a formal requirement.
   Remedy: always include the standard block; never omit it even if the user objects.
 
@@ -207,8 +214,8 @@ After the draft, tell the user:
   proof. PEC is preferred over the form because it leaves a traceable paper trail in the
   sender's hands.
 - **Alternative — AGID web form:** <https://www.agid.gov.it/it/form/difensore-civico-digitale>
-  (requires SPID or CIE login). The form collects the same information but provides no
-  receipt to the sender.
+  (requires SPID or CIE login). The form collects the same information but does not produce
+  PEC-style delivery receipts; save any confirmation page or protocol number the form displays.
 - The DCD has **90 days** to conclude the procedure (Regolamento art. 8). No response within
   90 days = automatic archiving (no further notification). The clock is suspended: up to 20
   days if AgID consults internal structures; during **10–20 August** and **25 December–1
@@ -221,7 +228,8 @@ Tell the user what happens next, to set realistic expectations:
 
 1. **Pre-istruttoria (art. 5 Regolamento):** The DCD reviews admissibility. If the complaint
    is inadmissible or irricevibile (too vague, wrong channel, duplicate), it is archived
-   silently with no notification.
+   without examination on the merits. The Regolamento does not guarantee a notification in
+   this case; the only explicit "no notification" rule is the 90-day non-avvio in art. 8.
 
 2. **Istruttoria (art. 6):** If the complaint passes, the DCD may request information from
    both the sender and the PA, with a 15-day peremptory deadline. Cooperate promptly.

--- a/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
+++ b/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
@@ -119,7 +119,7 @@ available that are actually inaccessible.
 
 **Common weaknesses for this category:**
 - Transient outage: if the issue was intermittent or already resolved at filing time, the DCD
-  will likely archive as irrilevante (art. 5c Regolamento). Collect dated evidence of
+  will likely archive under art. 5 lett. c Regolamento (carenza di elementi informativi). Collect dated evidence of
   persistence — screenshots with dates spanning several weeks, or a public status notice from
   the PA. Without this, the complaint is unlikely to proceed.
 

--- a/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
+++ b/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
@@ -5,6 +5,20 @@ legal arguments and adaptable Italian language into the complaint.
 
 Categories are not mutually exclusive — a single case can combine several.
 
+## Category disambiguation
+
+| Scenario | Category |
+|---|---|
+| Data published but in non-machine-readable format (PDF, HTML, map) | **A** |
+| Data nominally published but technically inaccessible (CAPTCHA, broken API, mandatory login) | **B** |
+| Data published but with a restrictive or missing license | **D** |
+| Data completely absent from the catalog | **G** |
+| Formal reuse request sent and unanswered past 30 days | **E** (requires delivery proof) |
+| Prior DCD complaint unacted on | **F** (requires prior protocol number) |
+
+A and B can overlap — cite both if wrong format AND access barrier coexist.
+G requires verifying absence on both dati.gov.it AND data.europa.eu before claiming total absence.
+
 ---
 
 ## Category A — Dati non in formato aperto / non machine-readable
@@ -103,6 +117,12 @@ available that are actually inaccessible.
 - Is the issue documented anywhere (no notice on the site)?
 - HTTP or HTTPS? What browser warning appears?
 
+**Common weaknesses for this category:**
+- Transient outage: if the issue was intermittent or already resolved at filing time, the DCD
+  will likely archive as irrilevante (art. 5c Regolamento). Collect dated evidence of
+  persistence — screenshots with dates spanning several weeks, or a public status notice from
+  the PA. Without this, the complaint is unlikely to proceed.
+
 **Articles to cite:** CAD art. 7 co. 1 (qualità servizi online); Linee guida di design AgID
 (TLS/HTTPS obbligatorio); CAD art. 17 co. 1-quater.
 
@@ -192,6 +212,13 @@ not provided the data, and not issued a motivated refusal.
 - Did the PA acknowledge receipt or request an extension?
 - Was a previous DCD complaint already filed about this?
 
+**Common weaknesses for this category:**
+- No PEC delivery receipts (ricevuta di accettazione + ricevuta di avvenuta consegna): without
+  these the user cannot prove the request was sent; the DCD will archive under art. 5c
+  Regolamento (carenza di elementi informativi). If receipts are unavailable, advise resending
+  the request via PEC and waiting out the 30-day deadline before filing.
+- Request sent via ordinary email, not PEC: produces no legal delivery proof; same consequence.
+
 **Articles to cite:** D.Lgs. 36/2006 art. 5 co. 1, 3; CAD art. 17 co. 1-quater.
 
 **Adaptable legal language (Italian):**
@@ -233,6 +260,14 @@ not remedied the violation.
 - Date of the previous segnalazione. Protocol number assigned by AGID?
 - Did you receive any response from the DCD?
 - Is the PA's conduct still the same as described in the original complaint?
+
+**Common weaknesses for this category:**
+- No protocol number: without it the DCD cannot link the two complaints and may treat the
+  follow-up as a fresh case. If the number is unavailable, use the submission date and PEC
+  delivery receipt as identifiers; note the gap explicitly in the complaint.
+- 90-day clock not yet expired: verify that 90 calendar days have passed, accounting for the
+  legal suspensions (10–20 agosto, 25 dicembre–1 gennaio, plus up to 20 days for internal
+  AgID consultation). Filing too early weakens the urgency argument.
 
 **Articles to cite:** CAD art. 17 co. 1-quater; Regolamento DCD art. 8; CAD art. 18-bis.
 
@@ -280,6 +315,14 @@ does not exist at all in the catalog.
   Draft one *segnalazione* per PA.
 - Have you verified on dati.gov.it filtering by the `hvd_category` field? What result?
 - Have you cross-checked on data.europa.eu for Italian datasets in this category?
+
+**Common weaknesses for this category:**
+- Not verified on data.europa.eu: if the dataset exists on the EU portal but not on dati.gov.it,
+  the violation is cataloging failure (weaker, closer to Category A) rather than total absence.
+  Always verify on both portals and document the search results in the complaint.
+- PA outside the HVD obligation scope: verify the PA is an "ente pubblico" under D.Lgs. 36/2006
+  art. 1 co. 2 and actually holds datasets in the claimed HVD category. Publicly owned but
+  private-law entities may not be obligated. If scope is uncertain, note it in the complaint.
 
 **Articles to cite:** Reg. (UE) 2023/138 artt. 3 par. 1 e 4 parr. 2–3; D.Lgs. 36/2006 artt.
 12-bis co. 1, 9 co. 2 e 12 ult. co.

--- a/skills/difensore-civico-ti-scrivo/references/normativa.md
+++ b/skills/difensore-civico-ti-scrivo/references/normativa.md
@@ -145,10 +145,32 @@ Conseguenze se mancanti: il DCD dichiara l'*inammissibilità* della segnalazione
 **Co. 5** — Eventuali specifiche e motivate esigenze di riservatezza/anonimato vanno
 dichiarate all'atto della segnalazione.
 
+### Art. 5 — Preistruttoria / Irricevibilità
+
+Il DCD dichiara l'**irricevibilità** (archiviazione senza esame nel merito) nei seguenti casi:
+
+- **a.** Incompetenza del Difensore digitale (la violazione non riguarda il CAD né norme di digitalizzazione).
+- **b.** Segnalazione eccessivamente generica o indeterminata.
+- **c.** Carenza di elementi informativi (descrizione insufficiente a identificare la violazione).
+- **d.** Identità della segnalazione con altra per la quale è già stato emesso un provvedimento.
+
+---
+
 ### Art. 8 — Termini
 
 Il procedimento si conclude entro **90 giorni** dalla ricezione. In assenza di avvio del
 procedimento entro 90 giorni, la segnalazione si intende archiviata senza comunicazione.
+
+Il termine è sospeso:
+- fino a **20 giorni** se il DCD richiede informazioni o pareri ad altre strutture AgID;
+- nei periodi **10–20 agosto** e **25 dicembre–1 gennaio**.
+
+---
+
+### Art. 9 — Riunione di procedimenti
+
+Il DCD può aggregare più segnalazioni contro lo stesso soggetto e trasmetterle in forma
+congiunta. Segnalazioni successive sulla stessa PA possono essere trattate insieme.
 
 ---
 


### PR DESCRIPTION
## Summary

- **difensore-civico-ti-scrivo**: strengthened with failure mechanism encoding, DCD procedural details, and output channel guidance — applying the validated 3-dimension rubric from Huang et al. 2026 (arXiv:2605.23899)
- **docs/**: added the paper as a project reference
- **CONTRIBUTING.md**: added skill writing guide linking to `skill-creator` and documenting the 3 validated content dimensions

## Changes

### `skills/difensore-civico-ti-scrivo/SKILL.md`
- New `## Common failure modes` section: 5 mechanisms (inadmissibility, wrong channel, premature complaint, weak evidence, delivery failure) each with executable remedy
- Step 4: PEC promoted to recommended channel (form leaves no receipt); new `## What to expect` section covering the full DCD procedure through to realistic outcomes and sanctions
- 90-day suspension periods added (10–20 Aug, 25 Dec–1 Jan)

### `references/categorie-violazioni.md`
- Category disambiguation table (A/B/D/G/E/F) at the top
- `Common weaknesses` blocks for categories C, E, F, G

### `references/normativa.md`
- Added Regolamento DCD art. 5 (irricevibilità — 4 causes)
- Updated art. 8 with suspension periods
- Added art. 9 (riunione procedimenti)

### `docs/from-raw-experience-to-skill-consumption-2026.md`
- Full markdown summary of Huang et al. 2026 — the paper that provided the rubric used here

### `CONTRIBUTING.md`
- New "Writing good skill content" section with the 3 validated dimensions, link to `skill-creator`, and note that format has no measurable effect on utility

## Test plan

- [ ] Read `SKILL.md` end to end — check failure modes are concrete and actionable
- [ ] Verify `categorie-violazioni.md` disambiguation table covers all categories
- [ ] Verify `normativa.md` art. 5 irricevibilità causes match Regolamento DCD text
- [ ] Try a Category E prompt (reuse request, no PEC receipts) — agent should warn before drafting
- [ ] Try a Funzione B prompt — agent must redirect, not draft

🤖 Generated with [Claude Code](https://claude.ai/claude-code)