### PR TITLE
difensore-civico: add Category H (stale/wrong IPA registry data)

### DIFF
--- a/skills/difensore-civico-ti-scrivo/SKILL.md
+++ b/skills/difensore-civico-ti-scrivo/SKILL.md
@@ -34,6 +34,18 @@ machine-readable API; obligations have been enforceable since 9 June 2024.
 **One complaint per PA.** If multiple administrations are involved, produce one *segnalazione*
 per administration.
 
+**The CAD is broad — references are a subset, not a closed list.** Art. 17, co. 1-quater CAD
+lets anyone report "presunte violazioni del presente Codice e di ogni altra norma in materia
+di digitalizzazione ed innovazione della pubblica amministrazione". The CAD alone has dozens
+of articles (identità digitale, domicilio digitale, pagamenti, conservazione, accessibilità
+dei dati, riuso, ecc.), and the reportable perimeter extends to *any* digitalization norm.
+The categories in `references/categorie-violazioni.md` and the articles in
+`references/normativa.md` are the most common cases, not an exhaustive catalogue. If the
+user's problem is a genuine digitalization-norm violation that no listed category fits, do
+not force-fit it or reject it: draft the complaint anyway, citing the relevant CAD article
+(or other norm) directly. Verify the exact wording and Normattiva URL of any article not
+already in the reference file before quoting it.
+
 ## Common failure modes
 
 These are the most frequent reasons a *segnalazione* fails or is dismissed. Check each before
@@ -107,6 +119,10 @@ the categories listed there. Each category maps to specific articles and provide
 Italian legal language. Confirm the match with the user before drafting.
 
 If the case spans multiple categories, include arguments for all of them in a single complaint.
+
+If no category fits but the facts describe a real digitalization-norm violation, proceed
+anyway under art. 17, co. 1-quater (see *Scope and constraints*): identify the specific CAD
+article (or other norm) breached and build the legal argument around it directly.
 
 ## Step 3 — Draft the complaint
 

--- a/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
+++ b/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
@@ -399,8 +399,8 @@ concerns the official records the PA is legally required to maintain *inside the
 its website works fine.
 
 **Additional questions to ask the user:**
-- Which entity? Capture its **Codice IPA** (univocal identifier) and the URL of its IPA public
-  page (https://www.indicepa.gov.it/ ... — the entity detail page).
+- Which entity? Capture its **Codice IPA** (unique identifier) and the URL of its IPA public
+  page (the entity detail page on https://www.indicepa.gov.it/).
 - Which datum is wrong or missing? (PEC del protocollo / domicilio digitale di una AOO /
   email / dominio web non risolvente / altro). Be specific.
 - What is the **data di ultima verifica** shown on the IPA public page? Is it older than 6
@@ -410,7 +410,7 @@ its website works fine.
 
 **Common weaknesses for this category:**
 - No specific datum identified: the DCD cannot invite the PA to fix "the IPA in general".
-  Pin down the exact field, the exact wrong value, and the correct expected behaviour.
+  Pin down the exact field, the exact wrong value, and the correct expected behavior.
 - No evidence the datum is actually wrong: a PEC that bounces, a `dig`/`nslookup` showing an
   NXDOMAIN, a screenshot of the IPA page with the stale verification date. Without dated proof
   the complaint risks archiviazione under art. 5 lett. c Regolamento (carenza di elementi).

--- a/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
+++ b/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
@@ -15,8 +15,14 @@ Categories are not mutually exclusive — a single case can combine several.
 | Data completely absent from the catalog | **G** |
 | Formal reuse request sent and unanswered past 30 days | **E** (requires delivery proof) |
 | Prior DCD complaint unacted on | **F** (requires prior protocol number) |
+| Entity's data in the IPA registry is outdated, wrong, or never verified (wrong/missing PEC or email, dead domain) | **H** |
 
 A and B can overlap — cite both if wrong format AND access barrier coexist.
+H differs from C: C is about the PA's website/service being broken; H is about the PA's
+official records *inside the IPA registry* (indicepa.gov.it) being wrong or stale — even if
+the PA's own site works. One *segnalazione* per PA: a systemic problem across many entities
+is still filed entity by entity to the DCD, never to the IPA Gestore (AgID-as-administrator
+is not a tutela channel; CAD violations go only to the DCD).
 G requires verifying absence on both dati.gov.it AND data.europa.eu before claiming total absence.
 
 ---
@@ -371,3 +377,85 @@ D.Lgs. 36/2006 / dell'art. 2, comma 2, del CAD — eliminare la variante non app
 o CC BY 4.0, le renda disponibili come download in blocco ove applicabile, e le cataloghi
 su dati.gov.it con il campo hvd_category valorizzato, nel rispetto del Reg. (UE) 2023/138
 e dell'art. 12-bis del D.Lgs. 36/2006."
+
+---
+
+## Category H — Dati nell'IPA non aggiornati, incompleti o errati
+
+**When:** A PA's records in the IPA — Indice dei domicili digitali delle pubbliche
+amministrazioni e dei gestori di pubblici servizi (indicepa.gov.it) — are wrong, incomplete,
+or stale: missing or invalid PEC/email, a non-PEC address where a domicilio digitale is
+required, a web domain that no longer resolves, or a "data di ultima verifica" older than six
+months. The CAD obliges every entity to keep its IPA data current and to verify it at least
+every six months; failing to do so is a CAD violation reportable to the DCD.
+
+This is distinct from Category C: C concerns the PA's own website/service being degraded; H
+concerns the official records the PA is legally required to maintain *inside the IPA*, even if
+its website works fine.
+
+**Additional questions to ask the user:**
+- Which entity? Capture its **Codice IPA** (univocal identifier) and the URL of its IPA public
+  page (https://www.indicepa.gov.it/ ... — the entity detail page).
+- Which datum is wrong or missing? (PEC del protocollo / domicilio digitale di una AOO /
+  email / dominio web non risolvente / altro). Be specific.
+- What is the **data di ultima verifica** shown on the IPA public page? Is it older than 6
+  months?
+- How was the error observed? (es. PEC che rimbalza, dominio che non risolve, contatto
+  inesistente). A dated, reproducible observation is essential.
+
+**Common weaknesses for this category:**
+- No specific datum identified: the DCD cannot invite the PA to fix "the IPA in general".
+  Pin down the exact field, the exact wrong value, and the correct expected behaviour.
+- No evidence the datum is actually wrong: a PEC that bounces, a `dig`/`nslookup` showing an
+  NXDOMAIN, a screenshot of the IPA page with the stale verification date. Without dated proof
+  the complaint risks archiviazione under art. 5 lett. c Regolamento (carenza di elementi).
+- Confusing the channel: the fix is requested from the DCD, which then invites the PA (the
+  data owner) to correct its own record. Do not address AgID-as-Gestore IPA: it administers
+  the registry but is not a tutela channel, and the responsibility for the data lies with each
+  entity (art. 6-ter co. 3 CAD).
+- Systemic phenomenon: if many entities are affected, this is still filed one *segnalazione*
+  per PA. Note the systemic context if useful, but the complaint must target one identified
+  entity with one identified error.
+
+**Articles to cite:** CAD art. 6-ter co. 3 (obbligo di aggiornamento e verifica almeno
+semestrale dei dati in IPA); CAD art. 47 co. 3 (PEC del protocollo da pubblicare in IPA per
+ciascuna AOO) ove rilevi una PEC errata/mancante; CAD art. 6-quinquies (IPA consultabile in
+formato aperto) ove rilevi sul dato pubblico; CAD art. 17 co. 1-quater.
+
+**Adaptable legal language (Italian):**
+
+```
+I dati di [ENTE] (Codice IPA: [CODICE]) pubblicati nell'Indice dei domicili digitali delle
+pubbliche amministrazioni e dei gestori di pubblici servizi (IPA) risultano [errati /
+incompleti / non aggiornati] nei seguenti termini:
+
+[DESCRIVERE il dato specifico: es. la PEC associata all'AOO [NOME] / il domicilio digitale /
+l'indirizzo email / il dominio web — con il valore attualmente presente in IPA]
+
+In particolare:
+- [CRITICITÀ 1 con evidenza e data di rilevazione: es. la PEC [indirizzo] restituisce errore
+  di mancata consegna in data [data]]
+- [CRITICITÀ 2: es. il dominio [dominio] non risolve (NXDOMAIN) alla data [data]]
+- [se applicabile] la "data di ultima verifica" riportata nella scheda pubblica dell'Ente è
+  [data], anteriore di oltre sei mesi rispetto alla data odierna.
+
+Ciò contrasta con:
+
+- l'art. 6-ter, comma 3, del CAD, che impone a ciascun soggetto iscritto di aggiornare
+  tempestivamente i propri dati nell'IPA e di verificarli almeno ogni sei mesi secondo le
+  indicazioni di AgID;
+[SE PEC ERRATA/MANCANTE:] - l'art. 47, comma 3, del CAD, che impone alle pubbliche
+  amministrazioni di pubblicare nell'IPA gli indirizzi di posta elettronica certificata a cui
+  inviare le comunicazioni e le istanze, per ciascun registro di protocollo;
+[SE RILEVA SUL DATO PUBBLICO:] - l'art. 6-quinquies del CAD, che configura l'IPA come elenco
+  pubblico consultabile da chiunque e realizzato in formato aperto, presupponendo dati
+  corretti e fruibili.
+
+L'impatto concreto è il seguente: [DESCRIVERE: impossibilità per cittadini, professionisti o
+altre PA di inviare comunicazioni valide a tutti gli effetti di legge al domicilio digitale
+dell'Ente, con pregiudizio per [istanze / notifiche / fatturazione elettronica / ...]].
+```
+
+**Remedy to request:** "inviti [ENTE] ad aggiornare e correggere senza ritardo i dati
+pubblicati nell'IPA — in particolare [DATO SPECIFICO] — e a procedere alla verifica periodica
+almeno semestrale prevista dall'art. 6-ter, comma 3, del CAD."

--- a/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
+++ b/skills/difensore-civico-ti-scrivo/references/categorie-violazioni.md
@@ -5,6 +5,11 @@ legal arguments and adaptable Italian language into the complaint.
 
 Categories are not mutually exclusive — a single case can combine several.
 
+These categories are a **non-exhaustive subset**. The CAD is a wide-ranging code and art. 17
+co. 1-quater opens the DCD to *any* digitalization-norm violation. If a case does not map to
+a category below but is a genuine breach, draft the complaint anyway, citing the relevant CAD
+article (or other norm) directly — do not force-fit it into the nearest category.
+
 ## Category disambiguation
 
 | Scenario | Category |

--- a/skills/difensore-civico-ti-scrivo/references/normativa.md
+++ b/skills/difensore-civico-ti-scrivo/references/normativa.md
@@ -3,6 +3,11 @@
 Compact reference for complaint drafting. Use these texts and URLs when citing articles.
 Source: D.Lgs. 7 marzo 2005, n. 82 (CAD), vigency 2026-05-29.
 
+This is a **curated subset** of the most frequently cited articles, not the full CAD. The
+code spans dozens of articles and art. 17 co. 1-quater extends the reportable perimeter to
+any digitalization norm. When a case requires an article not listed here, look up its exact
+wording and Normattiva URL on <https://www.normattiva.it/> before quoting it.
+
 ---
 
 ## CAD — D.Lgs. 7 marzo 2005, n. 82

--- a/skills/difensore-civico-ti-scrivo/references/normativa.md
+++ b/skills/difensore-civico-ti-scrivo/references/normativa.md
@@ -78,6 +78,51 @@ URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2
 
 ---
 
+### Art. 6-ter — Indice dei domicili digitali delle PA e dei gestori di pubblici servizi (IPA)
+
+> "[...] è istituito il pubblico elenco di fiducia denominato Indice dei domicili digitali
+> delle pubbliche amministrazioni e dei gestori di pubblici servizi, nel quale sono indicati i
+> domicili digitali da utilizzare per le comunicazioni e per lo scambio di informazioni e per
+> l'invio di documenti a tutti gli effetti di legge tra i soggetti di cui all'articolo 2,
+> comma 2, [...] e i privati."
+
+**Co. 3** — "Le amministrazioni di cui all'articolo 2, comma 2, lettere a) e b), e i gestori
+di pubblici servizi aggiornano gli indirizzi e i contenuti dell'Indice tempestivamente e
+comunque con cadenza almeno semestrale, secondo le indicazioni dell'AgID. La mancata
+comunicazione degli elementi necessari [...] e del loro aggiornamento è valutata ai fini
+della responsabilità dirigenziale e dell'attribuzione della retribuzione di risultato ai
+dirigenti responsabili." È l'obbligo principale violato quando un ente lascia dati IPA errati
+o stantii (Category H).
+
+URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2005-03-07;82~art6ter>
+
+---
+
+### Art. 6-quinquies — Consultazione e accesso agli elenchi
+
+> "La consultazione on-line degli elenchi di cui agli articoli 6-bis, 6-ter e 6-quater è
+> consentita a chiunque senza necessità di autenticazione. Gli elenchi sono realizzati in
+> formato aperto [...]."
+
+Rileva quando l'errore riguarda il dato pubblicamente consultabile in IPA.
+
+URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2005-03-07;82~art6quinquies>
+
+---
+
+### Art. 47, comma 3 — PEC del protocollo da pubblicare in IPA
+
+> "Le pubbliche amministrazioni e i gestori di pubblici servizi pubblicano, nell'Indice di cui
+> all'articolo 6-ter, gli indirizzi di posta elettronica certificata a cui inviare le istanze
+> e le dichiarazioni di cui all'articolo 65, e i documenti di cui al presente articolo, per
+> ciascun registro di protocollo."
+
+Da citare quando la criticità è una PEC del protocollo / di una AOO errata o mancante in IPA.
+
+URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2005-03-07;82~art47>
+
+---
+
 ## D.Lgs. 24 gennaio 2006, n. 36 (Riutilizzo informazione settore pubblico)
 
 ### Art. 5 — Richiesta di riutilizzo di documenti

--- a/skills/difensore-civico-ti-scrivo/references/normativa.md
+++ b/skills/difensore-civico-ti-scrivo/references/normativa.md
@@ -97,7 +97,7 @@ comunque con cadenza almeno semestrale, secondo le indicazioni dell'AgID. La man
 comunicazione degli elementi necessari [...] e del loro aggiornamento è valutata ai fini
 della responsabilità dirigenziale e dell'attribuzione della retribuzione di risultato ai
 dirigenti responsabili." È l'obbligo principale violato quando un ente lascia dati IPA errati
-o stantii (Category H).
+o stantii.
 
 URL: <https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legislativo:2005-03-07;82~art6ter>
 


### PR DESCRIPTION
## Summary

Adds a new violation category to the `difensore-civico-ti-scrivo` skill: **Category H — dati nell'IPA non aggiornati, incompleti o errati** (indicepa.gov.it records that are wrong/incomplete/stale).

## Changes

- `references/categorie-violazioni.md`: new Category H section — when to use, questions to ask, common weaknesses, articles to cite, adaptable Italian legal language and remedy
- distinguishes H (official IPA records the PA must maintain) from C (broken PA website)
- `references/normativa.md`: adds CAD art. 6-ter co. 3 (semi-annual update/verify duty), art. 6-quinquies (open public consultation), art. 47 co. 3 (PEC del protocollo in IPA)

One *segnalazione* per PA; complaint goes to the DCD (not to AgID-as-IPA-Gestore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)