### PR TITLE
datawrapper: arrow markers in locator maps + fix marker storage

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,11 @@
 # LOG
 
+## 2026-06-14
+
+- `datawrapper`: document arrow markers in locator maps (new Datawrapper feature). Tested end-to-end via pure API: arrows are writable (line + flow types, triangle/lines heads, bidirectional, gradient, taper, curve). Full JSON schema + per-field table added to `references/locator-map.md`
+- `datawrapper`: fix wrong marker storage in `references/locator-map.md` — there is NO `/markers` endpoint (404); points, areas and arrows are all stored in the chart data via `PUT /v3/charts/<ID>/data` as `{"markers":[...]}` (full replace each PUT). Corrected point (needs `icon` block) and area (colors in top-level `properties`, GeoJSON-style keys) examples
+- `datawrapper`: document counterintuitive `curve.angle` behaviour — values near 0 produce huge looping arcs; gentle curves need larger magnitudes that scale with arrow length (`|angle| ≈ km/2.5`); recommend tuning in GUI then reading back via API (verified by hand-edit round-trip)
+
 ## 2026-04-26
 
 - `typst-cards`: refactor starter templates to native page-level footer — `#set page(footer: footer-block(URL, dark: ...))` with Typst's `counter(page).display()` / `.final().first()`; replaces fragile `#v(1fr) + #ctr(n,total)` last-row pattern that produced silent ghost slides on dense content; new `footer-block` helper in theme; new pitfall entry; sub-case on literal helper params under special-chars table; smoke-tested both starters (5+3 PNGs, footer fully visible)

--- a/skills/datawrapper/references/locator-map.md
+++ b/skills/datawrapper/references/locator-map.md
@@ -112,7 +112,9 @@ curl -s -X PUT "https://api.datawrapper.de/v3/charts/<ID>/data" \
   --data-binary @markers.json
 ```
 
-`markers.json` contains every marker on the map (one PUT = full replace).
+`markers.json` is the full `{"markers":[...]}` object — every marker on the map
+(one PUT = full replace). The snippets below show a single marker each; put them
+as entries inside the `markers` array, do not PUT a bare object.
 
 ### Point markers
 ```json
@@ -261,4 +263,3 @@ that shows all of them, or use `fit` to define the bounding box.
 
 **Flows / movement** (migration, trade, routes): add `arrow` markers, one per
 origin→destination pair. Use `arrowType: "flow"` + `flowWeight` to encode volume.
-```

--- a/skills/datawrapper/references/locator-map.md
+++ b/skills/datawrapper/references/locator-map.md
@@ -1,8 +1,24 @@
 # Datawrapper — Creating a Locator Map
 
 A locator map shows WHERE something is located or happened. Chart type: `locator-map`.
-Unlike choropleth maps, locator maps use markers (points, areas, lines) placed on
+Unlike choropleth maps, locator maps use markers (points, areas, lines, arrows) placed on
 a basemap — they don't color regions by a data value.
+
+---
+
+## ⚠️ How markers are stored (read first)
+
+Markers are NOT a separate REST resource. There is **no `/markers` endpoint**
+(`GET`/`POST /v3/charts/<ID>/markers` both return 404). All markers — points,
+areas, and arrows — live in the chart **data**, written as a single JSON object:
+
+```json
+{ "markers": [ { ...marker1... }, { ...marker2... } ] }
+```
+
+Write them with `PUT /v3/charts/<ID>/data` (Content-Type `application/json`).
+Each PUT **replaces** the whole marker set — to add a marker, include all the
+existing ones too. `"metadata": {"data": {"json": true}}` must be set on the chart.
 
 ---
 
@@ -87,34 +103,130 @@ Note: `"data": {"json": true}` is required for locator maps.
 
 ## Adding markers
 
-Add markers after the base map is configured.
+Build the full `{"markers":[...]}` object and PUT it to `/data`:
+
+```bash
+curl -s -X PUT "https://api.datawrapper.de/v3/charts/<ID>/data" \
+  -H "Authorization: Bearer $DATAWRAPPER_API" \
+  -H "Content-Type: application/json" \
+  --data-binary @markers.json
+```
+
+`markers.json` contains every marker on the map (one PUT = full replace).
 
 ### Point markers
-```bash
-curl -s -X POST "https://api.datawrapper.de/v3/charts/<ID>/markers" \
-  -H "Authorization: Bearer $DATAWRAPPER_API" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "type": "point",
-    "coordinates": [12.492, 41.890],
-    "title": "Rome",
-    "visible": true
-  }'
+```json
+{
+  "id": "p1",
+  "type": "point",
+  "title": "Rome",
+  "coordinates": [12.49, 41.89],
+  "markerColor": "#c0392b",
+  "scale": 1.1,
+  "visibility": { "enabled": true },
+  "text": { "color": "#333333", "fontSize": 14, "enabled": true },
+  "icon": {
+    "id": "circle",
+    "path": "M1000 350a500 500 0 0 0-500-500 500 500 0 0 0-500 500 500 500 0 0 0 500 500 500 500 0 0 0 500-500z",
+    "horiz-adv-x": 1000, "scale": 1.1, "height": 700, "width": 1000
+  }
+}
 ```
 
+The `icon` block is required to get a visible symbol; `circle` is the safe default.
+
 ### Area markers
-```bash
-curl -s -X POST "https://api.datawrapper.de/v3/charts/<ID>/markers" \
-  -H "Authorization: Bearer $DATAWRAPPER_API" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "type": "area",
-    "coordinates": [[lon1,lat1],[lon2,lat2],[lon3,lat3],[lon1,lat1]],
-    "title": "Area label",
+The on/off toggles `fill`/`stroke` are top-level booleans; the colors live in a
+top-level `properties` object using GeoJSON-style keys. The geometry goes in
+`feature` (Polygon or MultiPolygon).
+```json
+{
+  "id": "ar1",
+  "type": "area",
+  "title": "Zone",
+  "fill": true,
+  "stroke": true,
+  "properties": {
     "fill": "#e74c3c",
-    "opacity": 0.4
-  }'
+    "fill-opacity": 0.35,
+    "stroke": "#c0392b",
+    "stroke-width": 1,
+    "stroke-opacity": 1
+  },
+  "feature": {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [[[11.0,42.0],[13.0,42.0],[13.0,43.5],[11.0,43.5],[11.0,42.0]]]
+    }
+  }
+}
 ```
+
+### Arrow markers
+Arrows show movement/connection between two points (`tail` → `tip`). Two styles:
+`"line"` (constant width) and `"flow"` (variable width, for volume).
+
+```json
+{
+  "id": "arrowA",
+  "type": "arrow",
+  "title": "Rome to Milan",
+  "color": "#c30711",
+  "opacity": 1,
+  "gradient": false,
+  "arrowType": "line",
+  "head": "triangle",
+  "lineWeight": "style0",
+  "flowWeight": 0,
+  "taper": { "direction": "tail", "headStrength": 0, "tailStrength": 0 },
+  "curve": { "angle": 0, "offset": 0.5 },
+  "coordinates": { "tip": [9.19, 45.46], "tail": [12.49, 41.89] },
+  "bidirectional": false,
+  "visibility": { "enabled": true },
+  "tooltip": { "enabled": false, "text": "" }
+}
+```
+
+Arrow fields:
+
+| Field | Values | Notes |
+|---|---|---|
+| `coordinates.tail` / `coordinates.tip` | `[lon, lat]` | tail = start, tip = end (where the head points) |
+| `arrowType` | `"line"` \| `"flow"` | `flow` = variable-width band (volume) |
+| `head` | `"triangle"` \| `"lines"` | arrowhead style |
+| `bidirectional` | `true` \| `false` | `true` = heads on both ends |
+| `curve.angle` | degrees | `0` = straight; sign = bulge side. **Counterintuitive** — see note below |
+| `curve.offset` | `0`–`1` | moves the arc apex along the arrow (`0.5` = middle) |
+| `lineWeight` | `"style0"` / `"style1"` / `"style2"` | thickness preset for `line` arrows |
+| `flowWeight` | number (e.g. `1`–`100`) | band thickness for `flow` arrows |
+| `gradient` | `true` \| `false` | fade the color along the arrow |
+| `taper` | `{direction, headStrength, tailStrength}` | shape of a `flow` band |
+| `color` / `opacity` | hex / `0`–`1` | |
+
+All arrow fields are writable via the API and render in the published map.
+Optional: `data.tipLabel` / `data.tailLabel` to label the endpoints,
+`groupId` to group markers.
+
+#### Curving an arrow (important)
+
+`curve.angle` is **not** "how much to curve" — its behaviour is counterintuitive
+and depends on the arrow's length:
+
+- `0` = straight (always safe).
+- Values **close to 0** (e.g. `5`, `-8`) produce a HUGE, looping arc, especially
+  on long arrows — not a gentle bend.
+- Natural, gentle curves use **larger** magnitudes, and the longer the arrow the
+  larger the angle needed. Rough heuristic: `|angle| ≈ chord_length_km / 2.5`.
+  Observed good values: short hop (~90 km) → `40`; cross-region (~230 km) → `~120`.
+- The **sign** flips which side the arc bulges. `curve.offset` (0–1) slides the
+  apex along the arrow.
+
+Because the mapping is non-linear, the reliable way to set a curve is to draw/adjust
+it once in the editor (`https://app.datawrapper.de/chart/<ID>/visualize`, step
+"Add markers"), then `GET /v3/charts/<ID>/data` and copy the resulting
+`curve.angle`/`curve.offset` back into your script.
 
 ---
 
@@ -146,3 +258,7 @@ use `fit` bounds so the area is always in view on all screen sizes.
 
 **Multiple cities comparison**: add multiple point markers, choose `zoom` level
 that shows all of them, or use `fit` to define the bounding box.
+
+**Flows / movement** (migration, trade, routes): add `arrow` markers, one per
+origin→destination pair. Use `arrowType: "flow"` + `flowWeight` to encode volume.
+```


### PR DESCRIPTION
## What

Adds documentation for the new **arrows in locator maps** Datawrapper feature, and fixes incorrect marker-storage docs.

All changes were verified end-to-end via pure API calls (create map → write markers → publish → export PNG → visual check).

## Changes (`references/locator-map.md`)

- **Arrow markers**: full JSON schema + per-field table — `arrowType` (`line`/`flow`), `head` (`triangle`/`lines`), `bidirectional`, `gradient`, `taper`, `curve`, `lineWeight`/`flowWeight`. Confirmed all fields are writable via API and render in the published map.
- **Fix marker storage**: there is **no `/markers` endpoint** (GET/POST both 404). Points, areas and arrows are all stored in the chart data via `PUT /v3/charts/<ID>/data` as `{"markers":[...]}` (each PUT fully replaces the marker set).
- **Corrected examples**: point markers need an `icon` block; area colors live in a top-level `properties` object with GeoJSON-style keys (`fill`, `fill-opacity`, `stroke`...).
- **Curve guidance**: `curve.angle` is counterintuitive — values near 0 produce huge looping arcs; gentle curves need larger magnitudes that scale with arrow length (`|angle| ≈ km/2.5`). Recommend tuning in the GUI then reading back via API (verified by hand-edit round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)