### PR TITLE
scrivi-chiaro-pa: new skill for plain-language PA writing

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,9 @@
 # LOG
 
+## 2026-07-28
+
+- `scrivi-chiaro-pa`: new skill — write, rewrite, or review Italian PA content in plain language, based on the Designers Italia *Guida al linguaggio della Pubblica Amministrazione* (CC-BY 4.0). Three modes (draft / rewrite / review), tone-of-voice scenarios, final glossary pass + checklist. References: style/grammar/numbers, structure/usability/SEO/accessibility, tone of voice (9 scenarios), social/newsletter/images/editorial management, A–Z glossary (~90 terms in two tables). Content harvested from the published "bozza" on docs.italia.it (suggerimenti + tono di voce sections exist only there) and from the `italia/writing-toolkit` repo (glossary RST sources)
+
 ## 2026-06-14
 
 - `datawrapper`: document arrow markers in locator maps (new Datawrapper feature). Tested end-to-end via pure API: arrows are writable (line + flow types, triangle/lines heads, bidirectional, gradient, taper, curve). Full JSON schema + per-field table added to `references/locator-map.md`

--- a/skills/scrivi-chiaro-pa/SKILL.md
+++ b/skills/scrivi-chiaro-pa/SKILL.md
@@ -87,7 +87,7 @@ Apply the style, structure, and tone rules. When rewriting:
 - [ ] The first sentence answers the reader's main question or states the required action
 - [ ] Sentences and paragraphs are short; no information is duplicated
 - [ ] Verbs are active and direct; no impersonal or passive bureaucratic forms
-- [ ] No unexplained acronyms: full name first, acronym after (only first letter capitalized, salvo exceptions: PA, UE, IVA, SPID, GU, MEPA, IRPEF, PM)
+- [ ] No unexplained acronyms: full name first, acronym after (only first letter capitalized, with exceptions: PA, UE, IVA, SPID, GU, MEPA, IRPEF, PM)
 - [ ] Numbers, dates, times, percentages follow the rules in `references/stile-di-scrittura.md`
 - [ ] Normative references are summarized in the text and cited precisely in notes with links
 - [ ] Language is inclusive (feminine forms, "persone con disabilità", no stereotypes)

--- a/skills/scrivi-chiaro-pa/SKILL.md
+++ b/skills/scrivi-chiaro-pa/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: scrivi-chiaro-pa
+description: >
+  Write, rewrite, or review Italian public administration content in plain language
+  (linguaggio chiaro), applying the Designers Italia language guide. Use this skill whenever
+  someone needs to: draft or simplify a PA text (avviso, lettera al cittadino, pagina web
+  istituzionale, email, comunicato, post social, newsletter, modulo, messaggio di errore o di
+  conferma); remove bureaucratese (burocratese) from a text; check a PA text for clarity,
+  accessibility, inclusiveness, or tone; choose the right tone of voice for a citizen-facing
+  digital service (registration, payments, password recovery, search results, blog). Triggers
+  include "scrivi in linguaggio chiaro", "semplifica questo avviso", "riscrivi per i
+  cittadini", "questo testo è troppo burocratico", "scrivi un post per il Comune", even if
+  the user does not name the skill — any request to produce or improve citizen-facing Italian
+  PA communication is a candidate.
+---
+
+# scrivi-chiaro-pa
+
+Helps Italian public administrations (and anyone writing on their behalf) communicate clearly with people, applying the *Guida al linguaggio della Pubblica Amministrazione* by Designers Italia.
+
+All output is in **Italian** (unless the user asks for another language). These instructions are in English; the rules and examples in `references/` preserve the original Italian wording where it matters.
+
+## Source and attribution
+
+Rules are adapted from the [Guida al linguaggio della Pubblica Amministrazione](https://docs.italia.it/italia/designers-italia/writing-toolkit/it/bozza/index.html) (Designers Italia — Team per la Trasformazione Digitale / AgID), published as a draft ("bozza") and licensed [CC-BY 4.0](https://github.com/italia/writing-toolkit/blob/master/LICENSE). When the user asks where a rule comes from, cite this guide.
+
+## Modes
+
+Pick the mode from the user's request; if ambiguous, ask.
+
+1. **Draft** — write a new text from scratch, given topic, audience, and channel.
+2. **Rewrite** — take an existing PA text and rewrite it in plain language, preserving its legal and factual meaning.
+3. **Review** — audit a text and report problems without rewriting it (unless the user then asks for the fix).
+
+## Core principles (always apply)
+
+- **Answer the citizen's question first.** Before writing, identify what the reader needs to know or do, and lead with it. Answer: chi, cosa, dove, come, quando.
+- **Short and simple.** Short sentences, short paragraphs. Most readers are on a phone. Do not repeat the same information in different places — link instead.
+- **Active, direct verbs.** *"Registrati sul sito"*, not *"La registrazione può essere effettuata sul sito"*. Avoid impersonal forms (*"È possibile iscriversi…"*).
+- **No bureaucratese.** Avoid nominalizations in "-zione"/"-mento", archaic formulas (*"ad uopo"*, *"nelle more di"*), and jargon. Prefer everyday words: the glossary lists the most common offenders and their plain alternatives.
+- **Concrete examples.** An example explains more than a long abstract explanation.
+- **Norms in footnotes, not in the flow.** Summarize what a law means for the reader; put the exact reference in a note with a link (e.g. Normattiva permalink). Never write like *"ex art. 20 comma 2 e 3 della legge n. 247/2012"* in body text.
+- **Inclusive language.** Feminine forms for office holders who are women (*la sindaca*, *la ministra*), "persone con disabilità", no stereotypes or generalizations by origin, religion, gender.
+- **Tone follows context.** A payment confirmation, a password recovery, and a blog post need different tones. Match the reader's state of mind.
+
+## Workflow
+
+### Step 1 — Frame the job
+
+Establish (ask only for what is missing and material):
+
+- mode (draft / rewrite / review);
+- content type and channel: web page, avviso/lettera, email or PEC, social post, newsletter, form or UI microcopy (buttons, errors, confirmations), blog post, attached document;
+- audience (all citizens, businesses, professionals, a specific group);
+- for rewrites/reviews: the original text.
+
+### Step 2 — Load the relevant references
+
+| Content type | Read |
+|---|---|
+| Any text, always | `references/stile-di-scrittura.md` + final glossary pass (`references/glossario-parole-pa.md`) |
+| Web page, avviso, lettera, document | `references/struttura-e-leggibilita.md` |
+| Form, UI microcopy, service touchpoint (registration, payment, recovery, search, area personale) | `references/tono-di-voce.md` + usability section of `references/struttura-e-leggibilita.md` |
+| Social post, newsletter, images/video, editorial planning | `references/canali-e-redazione.md` |
+| Blog post | `references/tono-di-voce.md` (blog scenario) + `references/stile-di-scrittura.md` |
+
+### Step 3 — Choose the tone of voice
+
+For citizen-facing service texts, match the situation to one of the nine scenarios in `references/tono-di-voce.md` (or interpolate between the closest ones): identify the reader's likely state of mind, then adopt the corresponding response approach.
+
+### Step 4 — Write or rewrite
+
+Apply the style, structure, and tone rules. When rewriting:
+
+- preserve legal and factual meaning exactly — simplify the language, never the obligations, deadlines, or conditions;
+- keep every normative reference, but move it to a note with the full name of the norm and a link;
+- keep proper names, dates, amounts, and protocol numbers verbatim;
+- match the output format to the channel (e.g. plain text for a letter or PEC, markdown-free; short lines and a strong first sentence for social).
+
+### Step 5 — Final pass
+
+1. Scan the text against `references/glossario-parole-pa.md` and replace or fix every term it flags.
+2. Run the checklist below; fix what fails.
+
+## Final checklist
+
+- [ ] The first sentence answers the reader's main question or states the required action
+- [ ] Sentences and paragraphs are short; no information is duplicated
+- [ ] Verbs are active and direct; no impersonal or passive bureaucratic forms
+- [ ] No unexplained acronyms: full name first, acronym after (only first letter capitalized, salvo exceptions: PA, UE, IVA, SPID, GU, MEPA, IRPEF, PM)
+- [ ] Numbers, dates, times, percentages follow the rules in `references/stile-di-scrittura.md`
+- [ ] Normative references are summarized in the text and cited precisely in notes with links
+- [ ] Language is inclusive (feminine forms, "persone con disabilità", no stereotypes)
+- [ ] Links have a clear destination ("Leggi la scheda X", never "clicca qui")
+- [ ] Tone matches the scenario and the reader's state of mind
+- [ ] Titles ≤ 65 characters, summary ≤ 150 characters (web content)
+
+## Review mode output
+
+Report findings as a list, most severe first. For each: quote the passage, name the problem, cite the rule area (style / structure / tone / glossary / accessibility), and propose the fixed wording in Italian. Close with an overall assessment and the three highest-impact fixes.

--- a/skills/scrivi-chiaro-pa/references/canali-e-redazione.md
+++ b/skills/scrivi-chiaro-pa/references/canali-e-redazione.md
@@ -1,0 +1,77 @@
+# Social, newsletter, images, editorial management
+
+Rules for channels beyond the website, and for planning and maintaining content over time.
+
+## Social media
+
+### Language
+
+Social feels informal, and a public body may adopt a more conversational tone — but it still represents an institution:
+
+- no coarse language, dialect forms, sloppy grammar, or heavy rhetorical figures;
+- no personal opinions, not even a "like";
+- tone can be lighter, substance stays accurate.
+
+### Plan the channels
+
+- Choose which social networks to be on based on goals and content type: news, event promotion, citizen assistance, community life.
+- Write a publication plan: what to post, how often, who produces and publishes, what gets monitored (analytics, interactions) against which goals.
+- Social content is ephemeral: durable information belongs on the institutional site (e.g. a news page) and gets promoted via social, not the other way around.
+
+### Use interaction as a resource
+
+Social channels are two-way. Monitor them on a schedule, route requests to the right contact channels, and use them for participation: informal consultations (a school polling parents on a trip destination) or collective initiatives (a municipality collecting ideas for New Year events).
+
+## Newsletter
+
+- Clarify recipients (citizens, professionals, businesses) and the informative purpose of each issue: update on news, or involve people in initiatives.
+- Plan issues in an editorial calendar with periodic team meetings; write collaboratively (shared documents) so subject experts can review.
+- Keep it short and mobile-friendly; link to the site for depth. Few topics per issue — the most important ones.
+- The subject line explains the most relevant content in one line (e.g. *"Novità sul bando del servizio civile"*). Title, summary, and paragraphs in the body if they help.
+- Multimedia is fine without excess: pertinent, mobile-friendly, no heavy images. Buttons help drive actions (e.g. *"Registrati adesso!"*).
+- The template must match the site's visual identity (logo, colors, fonts) and stay the same across issues. Send test issues and review before sending.
+- 24 hours after each send, read delivery/open/click data and use it to improve the next issues (low clicks on a topic → low pertinence; low open rate → subject line or topic problem).
+
+## Images and video
+
+### Publishing images
+
+- Invest in selection: a good photo adds value; skip useless photos, near-duplicate sequences, heavy files.
+- Always: rights cleared, author credited, license stated.
+- File name reflects the content (*teatro-antico-taormina.jpg*) — better indexing and findability.
+- Always add a caption and alt text (see `struttura-e-leggibilita.md`).
+- Optimize for the web before publishing: 72 ppi, JPG/PNG, RGB.
+
+### Managing the archive
+
+Name files with keywords (subject, date) or a uniform scheme; organize by theme or event; tag with alternative uses in mind; back up periodically. For team projects, use shared boards/dashboards so everyone can access and curate the photo selection.
+
+### Editing
+
+Free online tools cover simple image editing (crop, resize, brightness), social-format conversion, collages, and templates. For video, online tools handle small jobs like adding audio tracks, subtitles, or short GIF animations.
+
+## Content management
+
+### Plan before writing
+
+Analyze what people search for and focus on their needs. Every page has one clear purpose, defined first, in terms of the citizen need it answers (✅ *Questa pagina serve a spiegare cosa fa il Ministero dell'Interno.*). Never create multiple pages with the same purpose; delete pages without a clear goal. Do a content-journey exercise: what information do users look for, and where do they look for it.
+
+### Know the subject
+
+Before creating or revising content, study the topic. Ambiguous content usually comes from an unsure writer.
+
+### Keep content current
+
+- Updated content is credibility. Schedule periodic revisions; analyze user feedback.
+- Never write *"Pagina in aggiornamento"* or *"Questa pagina non è aggiornata"*.
+- Flag relevant updates to users with notes.
+- Remove obsolete content; when a page or section dies, redirect to its updated equivalent.
+
+### Review and test
+
+- Review old and new content periodically, on desktop and mobile; use collaborative tools for major revisions.
+- Run content audits involving other people, and user tests (usability tests, A/B tests) to check that content is clear and findable.
+
+### Measure
+
+Set measurable goals per page (more users, more service usage, less time to complete a task) and check them with analytics or tests.

--- a/skills/scrivi-chiaro-pa/references/glossario-parole-pa.md
+++ b/skills/scrivi-chiaro-pa/references/glossario-parole-pa.md
@@ -1,0 +1,107 @@
+# Glossary — le parole della Pubblica Amministrazione
+
+Recurring terms in PA texts, from the Designers Italia guide (not exhaustive). Use this file in the final pass: scan the text for these terms and apply the guidance.
+
+Two tables: bureaucratic or foreign terms to replace, and spelling/capitalization rules for names, institutions, and acronyms.
+
+## Bureaucratese and foreign terms — replace or limit
+
+| Term | Guidance |
+|---|---|
+| abrogare (abrogazione) | Only in normative contexts; elsewhere use "eliminare" |
+| adempiere (adempimento) | Use simpler wording: ✅ *Per metterti in regola con gli obblighi vaccinali dovrai…* ❌ *Regolarizzazione iscrizioni per adempiere agli obblighi vaccinali…* |
+| alienazione | Use "vendita" or "trasferimento della proprietà" |
+| ammenda | Use "multa" or "contravvenzione" |
+| best practice | Use "buona pratica" |
+| citizen satisfaction | Use "soddisfazione dei cittadini", explaining how it is measured |
+| concernere | Avoid, especially the participle: ✅ *Per dubbi su come utilizzare il servizio leggi la guida.* ❌ *Per domande concernenti il servizio consultare la guida.* |
+| conseguimento | Avoid the nominalization; use the verb: ✅ *Per raggiungere gli obiettivi…* ❌ *Per il conseguimento degli obiettivi…* |
+| contact center | Use "centro assistenza" |
+| disclaimer | Use "avvertenza", "informazioni importanti" |
+| ente | Don't overuse; prefer a specific name: ✅ *…sul sito del Comune.* ❌ *…sul sito dell'ente promotore.* |
+| erogare | Only water and funding get "erogato"; for services use "offrire", "fornire", or just state availability: ✅ *Il servizio è disponibile dal lunedì al venerdì…* |
+| Faq / Frequently asked questions | Use "Domande frequenti"; better, avoid FAQ pages entirely (fix the content instead) |
+| feedback | Use "valutazione", "commenti", "riscontro" |
+| guideline | Use "linea guida" |
+| help desk | Use "assistenza", "servizio di assistenza" |
+| implementare | Only for software, sparingly; for norms and reforms use "realizzare", "mettere in pratica", "attuare" |
+| interlocuzione | Citizens talk, they don't "interloquire": use "dialogo", "discussione", "confronto", "consultazione" |
+| locazione | Use "affitto": ✅ *L'immobile viene affittato a partire da…* |
+| meeting | Use "riunione", "incontro" |
+| mission | Marketing jargon; use "valori", "scopi", "obiettivi" |
+| nelle more di | Bureaucratic formula; use plain wording: ✅ *In attesa del giudizio del tribunale.* ❌ *Nelle more del giudizio del tribunale.* |
+| ratificare | Only in normative contexts; elsewhere "approvare", "confermare" |
+| speaker | Use "relatore/relatrice" |
+| supportare | Only for mechanical supports; otherwise say concretely how you help ("aiutare", "sostenere") |
+| tool | Use "strumento" |
+| username | Prefer "nome utente" |
+| vision | Marketing jargon; use "scenario futuro", "obiettivi di lungo periodo" |
+
+## Spelling and capitalization of names, institutions, acronyms
+
+| Term | Rule |
+|---|---|
+| Agenda digitale (italiana) | Only the first letter capitalized |
+| Agenzia per l'Italia Digitale | Acronym: AgID |
+| allegato | Lowercase |
+| Anagrafe Nazionale della Popolazione Residente | Acronym: Anpr (only first letter capitalized); generically, "anagrafe nazionale" |
+| Anas | Only first letter capitalized |
+| app / applicazione | Both fine, lowercase |
+| aziende sanitarie locali | All lowercase; acronym Asl (first letter capitalized) only after the full form |
+| banca | Capitalized only in proper names (Banca d'Italia) |
+| Camera di commercio | Only first letter capitalized |
+| Carta nazionale dei servizi, Cns | Only first letter capitalized |
+| Cassa depositi e prestiti, Cdp | Only first letter capitalized, acronym included |
+| Codice dell'amministrazione digitale | Write in full; only first letter capitalized; acronym Cad |
+| Commissione europea | Only first letter capitalized |
+| Comune / comuni | Capitalized for a specific body (*il Comune di Conversano*, even without the name); lowercase for the category (*i comuni*) |
+| Consiglio dei ministri, Cdm | Only first letter capitalized, acronym included |
+| Consiglio nazionale delle ricerche, Cnr | Only first letter capitalized |
+| Consip | Only first letter capitalized |
+| conto corrente, c/c | Prefer the full form; abbreviation only after using it |
+| Corte | Only first letter capitalized (Corte costituzionale, Corte d'appello, Corte di cassazione) |
+| Costituzione | Always capitalized |
+| decreto legge / decreto legislativo | Write in full in body text; "d.l." and "d.lgs." only in precise references; lowercase |
+| Docs Italia | Both initials capitalized, no hyphens |
+| eccetera | "ecc." in lists; whichever form, keep it uniform |
+| email | Lowercase, no hyphens or spaces |
+| euro | In text write "250 euro"; in tables "250 €" (symbol after, with space); plural "euri" legal but avoid |
+| Gazzetta Ufficiale, GU | Acronym all caps, only after the full form "Gazzetta Ufficiale (GU)" |
+| GitHub | Capital G and H |
+| giudice | Lowercase, except with the full title + name (*il Giudice della Corte costituzionale Nome Cognome*); feminine invariant (*la giudice*) |
+| Governo | Capitalized when referring to the sitting government of a country |
+| imposta sul reddito delle persone fisiche, IRPEF | Acronym all caps; full form lowercase |
+| imposta sul valore aggiunto, IVA | Acronym all caps; full form lowercase |
+| Inps | Only first letter capitalized |
+| Istat | Only first letter capitalized |
+| legge | Lowercase, unless citing the exact name (*Legge di Bilancio 2018, Legge 205/2017*) |
+| Mercato elettronico della PA, MEPA | Platform capitalized; acronym all caps |
+| ministero | Lowercase, unless full name (*Ministero dell'ambiente e della tutela del territorio e del mare*) |
+| ministro | Lowercase, unless full title (*Il Ministro per lo sviluppo economico Nome Cognome*); feminine *la ministra* |
+| newsletter | Feminine in Italian |
+| online | Prefer "online" over "on-line"/"on line"; keep it uniform |
+| Paese | Capitalized as synonym of a specific nation/state; otherwise lowercase |
+| pagoPA | Lowercase first letter |
+| Parlamento | Always capitalized |
+| Pin, codice Pin | First occurrence "codice Pin"; only first letter capitalized |
+| posta elettronica certificata, Pec | Acronym: only first letter capitalized; full form lowercase |
+| Presidente del Consiglio dei ministri | "Presidente" and "Consiglio" capitalized; feminine invariant (*la Presidente*) |
+| Presidente della Repubblica | "Presidente" and "Repubblica" capitalized; feminine invariant |
+| Procura della Repubblica | Both initials capitalized |
+| Protezione civile | Only first initial capitalized, also in "Dipartimento della protezione civile" |
+| Pubblica Amministrazione, PA | Full form first, then the acronym; initials capitalized |
+| pubblico ministero, PM | Full form lowercase; acronym all caps; feminine invariant |
+| Repubblica | Always capitalized |
+| sindaco | Lowercase, unless title + name (*Il Sindaco Giuseppe Rossi*); feminine *la sindaca* |
+| Sistema Pubblico di Identità Digitale, SPID | All initials capitalized, acronym all caps |
+| smartphone | One word, no hyphens |
+| Stati membri | Only "Stati" capitalized |
+| Stato | Capitalized |
+| tassa sui rifiuti, Tari | Prefer the full form; acronym only first letter capitalized |
+| Testo Unico | Both initials capitalized when written in full |
+| touch screen | Two words; "schermo tattile" also fine |
+| Ufficio relazioni con il pubblico, Urp | Prefer full form first; only first letter capitalized, acronym included |
+| Unione Europea | Both initials capitalized; abbreviated UE |
+| università | Lowercase, unless full name (*Università degli studi di Bologna*) |
+| Wi-Fi | Capitalized initials, with hyphen; masculine (*il Wi-Fi*), "la (rete) Wi-Fi" acceptable |
+| YouTube | One word, capital Y and T |

--- a/skills/scrivi-chiaro-pa/references/stile-di-scrittura.md
+++ b/skills/scrivi-chiaro-pa/references/stile-di-scrittura.md
@@ -1,0 +1,86 @@
+# Writing style, grammar, numbers, formatting
+
+Rules for how to write Italian PA text: style, verbs, punctuation, numbers and dates, text formatting. Examples are quoted in Italian from the Designers Italia guide (✅ = use, ❌ = avoid).
+
+## Style
+
+### Go straight to the point
+
+Before writing, ask what the reader needs and answer it. Answer the key questions: chi, cosa, dove, come, quando. Do not write more than needed and do not repeat the same information in different places — link instead.
+
+### Short, simple language
+
+Short sentences, short paragraphs: most reading happens on a phone screen. Include, don't exclude: use words everyone understands, avoid periphrases and archaic words (*"ad uopo"*, *"nelle more di"*). Avoid words ending in "-zione" or "-mento" (nominalizations): use the active verb instead.
+
+- ✅ *Completa il modulo e paga* / *Per semplificare devi: …*
+- ❌ *Prima di pagare procedi al completamento del modulo* / *Le procedure di semplificazione prevedono che: …*
+
+Compare word usage with tools like Google Trends and pick the words people actually use.
+
+### Verbs
+
+- Active forms: ✅ *Registrati sul sito.* ❌ *La registrazione può essere effettuata sul sito.*
+- Colloquial and direct: ✅ *Scarica il bando per la richiesta dei contributi.* ❌ *Il cittadino interessato può reperire il bando per la richiesta di contributi in questa sezione.*
+- No impersonal forms: ✅ *Iscriviti sul sito del Comune.* ❌ *È possibile iscriversi sul sito del Comune.*
+
+### Examples
+
+Always use concrete examples to explain: an example clarifies a concept better than a long explanation.
+
+### Acronyms
+
+Avoid acronyms where possible. When an acronym is widespread and genuinely helps:
+
+- write the full name first, then the acronym: *"Il bando è stato pubblicato dal Ministero dello sviluppo economico (Mise). Il Mise ha anche reso noto…"*;
+- as a rule only the first letter is capitalized (*Mise*, *Mipaaf*); frequent exceptions: PA, UE, IVA (and see the glossary for SPID, GU, MEPA, IRPEF, PM).
+
+### Institutional offices and names
+
+- Lowercase for offices: sindaco, giudice, assessore, ministro. Exceptions: Presidente della Repubblica, Presidente del Consiglio dei ministri.
+- Ministries and departments: only the first initial is capitalized — *Ministero della difesa*, *Dipartimento della protezione civile*. Same for their acronyms.
+
+### Names of services and projects
+
+Use simple, descriptive names, not brands: ✅ *Servizio di assistenza del Comune* ❌ *Linea amica*.
+
+### Foreign words
+
+- Prefer the Italian term when possible.
+- Italics for foreign words that are not common use (unless in a technical context).
+- Common foreign words do not take plural inflection in Italian: *"l'amministrazione ha comprato dieci tablet"*, not *"tablets"*.
+
+### Normative references
+
+Keep the text clear; avoid piling up references.
+
+- Summarize what the norm means instead of quoting it, so the reader gets the intent.
+- Put the precise reference in a note: short extract plus the full name of the norm.
+- Avoid technical citation style in body text (❌ *ex ART. 20 comma 2 e 3 della legge n. 247/2012*).
+- Always link the norm, e.g. with its Normattiva permalink.
+- Multiple norms: use a list, one norm per item, each with full name and link.
+
+### Symbols
+
+Prefer words over symbols like "&" or "%": *"Il 50 per cento degli abitanti"*. See Percentages below for the exceptions.
+
+## Numbers, dates, times
+
+- **Dates**: form *"01 gennaio 2018"*. Days and months lowercase (*lunedì 15 marzo*).
+- **Numbers**: generally in words. Use digits for precise data (math, science, statistics, prices), dates, addresses (*Via del Corso 15*). Before "mille/mila/milione/miliardo" with indicative value, use digits: *4 milioni e 325 mila persone*. Decimal separator is the comma: *2,5 metri*.
+- **Roman numerals**: only for precise references to laws (*Titolo V della Costituzione*) and centuries.
+- **Times**: in words in discursive contexts (*le quattro e mezzo*); digits for precise times, with colon and no spaces (*23:59*).
+- **Percentages**: "%" only in tables or technical/statistical content; otherwise digits + "per cento": *La popolazione è aumentata del 3 per cento.*
+- **Units of measure**: technical documents → digits + SI symbol with a space (*3 km*, *15 kg*, *25 °C*); elsewhere words are fine (*tre chilometri*, *25 gradi*).
+
+## Punctuation and grammar
+
+- *"Per esempio"* written out in body text; *"es."* acceptable inside parentheses.
+- NEVER WRITE WHOLE SENTENCES IN CAPS — it hurts readability. Default to lowercase initials except proper nouns and exceptions: full institutional titles followed by the name (*il Ministro per le politiche agricole Nome Cognome*), universities/faculties/institutes, full names of offices and agencies (*Agenzia delle Entrate*), specific references to laws, required capitals (*Unione Europea*).
+- Semicolon for list items, full stop to close sentences. After a full stop → capital; after semicolon or colon → lowercase. In bullet lists: if the intro sentence ends with a full stop, each item starts with a capital and ends with a full stop; if the intro ends with a colon, items start lowercase and end with a semicolon (last item: full stop).
+
+## Text formatting
+
+- **Italics**: only for bibliographic references, works of art/film, and uncommon foreign words. It slows reading.
+- **Bold**: prefer headings and lists for emphasis; in body text, bold only for keywords.
+- **Underline**: never — on the web it means "link".
+- **Tables**: useful for concepts, but keep text inside cells minimal and use few columns (mobile readability).

--- a/skills/scrivi-chiaro-pa/references/struttura-e-leggibilita.md
+++ b/skills/scrivi-chiaro-pa/references/struttura-e-leggibilita.md
@@ -1,0 +1,93 @@
+# Structure, usability, findability, accessibility
+
+How to structure content, write UI microcopy, make text findable by search engines, and keep it accessible and inclusive. Examples in Italian (✅ = use, ❌ = avoid).
+
+## Structuring content
+
+### Paragraphs
+
+Split content into short paragraphs so the reader finds information fast. Assume mobile reading.
+
+### Lists
+
+- Bullet lists make text more readable. Items must be consistent with the intro sentence, short and clear, correctly aligned (punctuation rules: see `stile-di-scrittura.md`).
+- Numbered lists guide the reader through a process, one action per step, no intro sentence needed. Link any documents needed to complete the step.
+- Avoid nested sub-lists: start a new list instead.
+
+### Links
+
+- Make the destination or purpose of every link clear from its text: ✅ *Leggi la scheda di sintesi Rapporto sull'attuazione del Servizio Civile: anno 2017* ❌ *Leggi qui la scheda…*. Never "clicca qui".
+- Only link genuinely relevant content — too many links blur the text.
+- Open links in the same tab, with few exceptions (e.g. another site).
+
+### Navigation menus and labels
+
+Write labels from the user's point of view: simple, common, immediately understandable terms. Keep one syntactic approach — do not mix verb-based (*"Scarica il documento"*), noun-based (*"Documenti scaricabili"*) and questions. ✅ *Servizi per le imprese* ❌ *Imprese*. Labels drive the user's mental model of the site: keep tone, granularity, and style consistent.
+
+### Notes
+
+On a web page, use footnotes only for normative references. For further reading, bibliographies, or technical documents, use lists with links instead.
+
+### FAQ
+
+Do not create FAQ sections that duplicate content. If a question is frequent, fix the page that should answer it.
+
+### Contact details
+
+- **Email**: lowercase, no hyphens or spaces, always an active `mailto:` link.
+- **Phone numbers**: always alongside other contact channels; include the international prefix and group digits with spaces (*+39 06 123 456 78*); make them active `tel:` links.
+
+### Attached documents and PDFs
+
+Write content as web pages, not attachments. If an attachment is unavoidable (e.g. some norms): clear and accessible text, correct heading hierarchy and metadata, no blank pages or filler images, a description of the document on the page before the link, and the link must state file type and size.
+
+### Data
+
+Prefer visual presentation (charts, maps) over big tables; tables have mobile and readability limits. When tables are needed: little text per cell, few columns.
+
+## Usability and microcopy
+
+### Buttons
+
+Clear, specific calls to action: ✅ *"Cerca"*, *"Paga adesso"*, *"Scarica il modulo"*, *"Iscriviti adesso"* ❌ *"Ok"*, *"Invia"*. Mind the difference between *"Cancella"* and *"Annulla"*. Button text must state the action performed: ✅ *Conferma i tuoi dati* ❌ *Clicca qui*.
+
+### Confirmation messages
+
+Always confirm the outcome of a user action with text. If a further action follows, explain its consequence:
+
+- ✅ *Premendo "Conferma" invierai la tua richiesta e non potrai più modificare i dati* → [Conferma] [Annulla]
+- ❌ *Confermi?* → [Invia] [Annulla]
+
+### Error messages
+
+Say exactly what is missing or wrong and how to fix it: ✅ *Inserisci un numero di telefono valido. Tutti i campi con l'asterisco (\*) sono obbligatori* ❌ *Errore*.
+
+### Form microcopy
+
+Add short instruction or example texts to form fields, so the user knows what information is expected and how to use the interface.
+
+### Empty pages
+
+Never leave dead ends (e.g. empty search results). Offer a way forward: ✅ *La ricerca di "[parole chiave]" non ha prodotto nessun risultato. Torna alla pagina precedente per una nuova ricerca, oppure vai alla pagina contatti.* ❌ *Not found*.
+
+## Writing for search engines
+
+- **Titles**: max 65 characters, clear and descriptive, search-friendly, no special characters, no trailing full stop, normal capitalization rules, no acronyms. ✅ *Riduci, riusa, ricicla: come gestire i rifiuti a Venezia* ❌ *Io riduco, riuso, riciclo*.
+- **Summaries** (page description): on every page, max 150 characters, ends with a full stop, does not repeat title or body, clear and specific.
+- **Keywords**: build a list of the terms that define the site's topics, drop synonyms, prefer the simplest terms (check Google Trends); use the list for menus and tags.
+- **Captions**: every image gets a short caption (max two lines), with author and license when needed.
+- **Migrations**: when content moves, set redirects to preserve indexing and not lose users arriving from search engines.
+
+## Accessibility and inclusion
+
+- **Contrast and font size**: check text/background contrast and avoid small type.
+- **Captcha**: never based only on images, audio, or color distinction.
+- **Alt text**: describe image/video content in the `alt` attribute — short, pertinent, specific, coherent with the text's keywords. Essential for accessibility.
+- **Interface never relies on color/image/audio alone**: buttons combine shape, color, and text.
+- **Content usable by everyone**: including people with motor, speech, sight, or age-related difficulties. Offer multiple contact channels (phone with prefix as a link, email as a link, address).
+- **Disability**: say *"persone con disabilità"*; avoid *"diversamente abile"*, *"disabile"*, *"handicappato"*, *"persone che soffrono di una disabilità"*.
+- **Feminine forms**: decline titles when the office holder is a woman — *la ministra*, *la sindaca*, *l'architetta*, *la giudice*, *l'ambasciatrice*; invariant terms stay (*la presidente*, *la dirigente*).
+- **Cultural identity**: use precise terms (richiedenti asilo, rifugiati, migranti irregolari); no generalizations by origin, ethnicity, religion, culture. ✅ *Nella notte sono sbarcate circa 30 persone.* ❌ *Nella notte sono sbarcati circa 30 clandestini.*
+- **Inclusive language**: people-first, no stereotypes; when giving examples, do not default to one gender (❌ *Il presidente di Acme, Mario Rossi…*).
+- **Jargon**: technical terms only if the audience surely understands them; otherwise use synonyms or explain briefly.
+- **Translations**: consider translations for critical content (health care, residence permits, emergencies — at least English). Machine translation is acceptable if verified, declared, and understandable; translate tags and metadata too.

--- a/skills/scrivi-chiaro-pa/references/tono-di-voce.md
+++ b/skills/scrivi-chiaro-pa/references/tono-di-voce.md
@@ -1,0 +1,97 @@
+# Tone of voice by context
+
+People arrive at PA services in different states of mind depending on what they are doing. The tone must adapt. Each scenario below gives: the user's likely state of mind, the approach the administration should use, and an example response in Italian from the Designers Italia guide.
+
+If the user's situation matches none of the scenarios, interpolate from the closest ones using the same method: name the reader's state of mind, then answer it with the matching tone qualities.
+
+## Quick map
+
+| Scenario | User feels | PA responds with |
+|---|---|---|
+| Registrarsi su un sito | diffidenza, fretta | trasparenza, chiarezza |
+| Primo accesso all'area personale | orientamento al risultato, rapidità | prontezza, indicazioni |
+| Recupero nome utente / password | preoccupazione, urgenza | rassicurazione, efficienza |
+| Pagamento online | concentrazione, perplessità | affidabilità, sicurezza |
+| Conferma di pagamento | attesa, incertezza, dubbio | successo, certezza |
+| Promemoria dei pagamenti | attenzione, tempestività | aggiornamento, precisione |
+| Riepilogo dei pagamenti | ansia | solidità, supporto |
+| Risultati di ricerca | determinazione, specificità | guida, personalizzazione |
+| Blog | curiosità, approfondimento | autorevolezza, complicità |
+
+## Scenarios
+
+### Registrarsi su un sito web
+
+User: *"Perché devo inserire tutte queste informazioni? Che uso ne fa l'amministrazione? A me serve solo poter usare il servizio."* — diffident, in a hurry.
+
+Approach: explain in simple words why each piece of data is requested (trasparenza); explain the use of optional fields and let people fill them later (chiarezza).
+
+Example: *"Registrati inserendo i dati obbligatori contrassegnati con l'asterisco per utilizzare il servizio. Puoi migliorare la tua esperienza completando la registrazione inserendo i dati facoltativi. Se non vuoi farlo adesso potrai farlo in un secondo momento, dalle impostazioni del tuo profilo personale."*
+
+### Primo accesso all'area personale
+
+User: *"Finalmente ho creato il mio profilo, ora spero di poter utilizzare subito i servizi senza perdere altro tempo."* — goal-oriented, wants speed.
+
+Approach: put available actions in front of the user immediately (prontezza); make guides and tutorials reachable but optional (indicazioni).
+
+Example: *"Benvenuto nella tua area personale. Puoi scoprire tutte le funzionalità a tua disposizione guardando il tutorial o accedere direttamente ai servizi."*
+
+### Recupero nome utente e password
+
+User: *"La scadenza per l'invio dei documenti è tra pochi giorni: sarà possibile recuperare la password in fretta?"* — worried, urgent.
+
+Approach: offer a fast solution right away (rassicurazione); be clear about steps and recovery time (efficienza).
+
+Example: *"Hai dimenticato il nome utente o la password? Recuperali seguendo i prossimi tre passaggi, sarai subito in grado di accedere di nuovo alla tua area personale."*
+
+### Pagamento online
+
+User: *"Sarà sicuro o mi conviene andare allo sportello?"* — focused, skeptical about security.
+
+Approach: reinforce the official identity of the administration (affidabilità); link detailed security information (sicurezza).
+
+Example: *"Benvenuto nel sistema di pagamento ufficiale della Pubblica Amministrazione. I nostri sistemi aggiornati garantiscono la sicurezza dei tuoi dati. [Leggi di più]"*
+
+### Conferma di pagamento
+
+User: *"Sono più tranquillo se ricevo la conferma ufficiale di aver fatto tutto correttamente."* — waiting, uncertain.
+
+Approach: celebrate the successful outcome, even in punctuation (successo); confirm without circumlocution (certezza).
+
+Example: *"Perfetto, abbiamo ricevuto il tuo pagamento! Adesso puoi scaricare la ricevuta."*
+
+### Promemoria dei pagamenti
+
+User: *"Spero di non aver dimenticato nessuna scadenza."* — attentive, needs timely info.
+
+Approach: offer user-configured automatic notifications (aggiornamento); answer directly for the short term and give long-term visibility (precisione).
+
+Example: *"Per il prossimo mese non ci sono scadenze di pagamento. La prossima scadenza è tra due mesi: vuoi un promemoria via email? Seleziona la data in cui desideri riceverlo."*
+
+### Riepilogo dei pagamenti
+
+User: *"Spero di ritrovare la ricevuta della multa, non ricordo dove l'ho salvata."* — anxious.
+
+Approach: show the completeness of the personal archive right away (solidità); help the user filter and narrow results (supporto).
+
+Example: *"Questo è l'elenco completo dei tuoi pagamenti. Seleziona dal calendario le date del periodo che ti interessa per restringere i risultati."*
+
+### Risultati di ricerca
+
+User: *"Cerco 'asili nido' nel sito del mio Comune per capire quali hanno posti disponibili."* — determined, looking for something specific.
+
+Approach: help the user exploit search options (guida); suggest refinements based on the query (personalizzazione).
+
+Example: *"Per avere risultati più precisi rispetto alle tue esigenze, filtra utilizzando il cap della zona in cui cerchi l'asilo nido."*
+
+### Blog
+
+User: *"Leggo il blog perché trovo novità e approfondimenti sugli argomenti che mi interessano."* — curious, wants depth.
+
+Approach: build authority through quality in-depth content (autorevolezza); talk to a reader with real competence, allow a lighter register (complicità).
+
+Example: *"Nel nuovo articolo di Designers Italia ti raccontiamo come costruire un design system in dieci mosse e vivere felici."*
+
+## Social media note
+
+Social networks allow a more informal tone, but the account represents a public institution: no slang or dialect, impeccable grammar, no personal opinions (not even a "like"). See `canali-e-redazione.md`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,37 @@
 # onData Skills Project - Planning
 
+## New skill: writing for Italian PA (Designers Italia writing toolkit) — 2026-07-28
+
+Source: https://docs.italia.it/italia/designers-italia/writing-toolkit/it/bozza/index.html (CC-BY 4.0, repo `italia/writing-toolkit`)
+
+### Plan
+
+- [x] Confirm skill name and scope with user (`scrivi-chiaro-pa`, full scope incl. social/newsletter/images/editorial)
+- [x] Create branch `add/scrivi-chiaro-pa`
+- [x] Write `skills/scrivi-chiaro-pa/SKILL.md` (English instructions, Italian output/examples)
+- [x] Write `references/stile-di-scrittura.md` (style + punctuation/grammar + numbers and dates + formatting)
+- [x] Write `references/struttura-e-leggibilita.md` (structure, usability, SEO, accessibility)
+- [x] Write `references/tono-di-voce.md` (9 scenarios: user mood → PA response approach)
+- [x] Write `references/canali-e-redazione.md` (social, newsletter, images/video, content management)
+- [x] Write `references/glossario-parole-pa.md` (single file, two tables: bureaucratese + spelling/capitalization)
+- [x] Add attribution note (CC-BY 4.0, Designers Italia) in SKILL.md
+- [x] Update LOG.md, open PR
+- [ ] Evals battery in `evals/scrivi-chiaro-pa/` (follow-up PR)
+
+### Source map (published "bozza" build)
+
+1. Le parole della PA — A–Z glossary, RST sources on GitHub (only section present in the repo)
+2. Suggerimenti di scrittura — 11 sub-pages: stile-di-scrittura, numeri-e-date, scrivere-per-i-motori-di-ricerca, accessibilita-e-inclusione, come-strutturare-il-contenuto, regole-di-formattazione, punteggiatura-e-grammatica, usabilita, immagini-video, social-e-newsletter, gestione-dei-contenuti
+3. Tono di voce — intro + 9 scenarios: registrarsi, primo-accesso, recupero-password, pagamento-online, conferma-pagamento, promemoria-pagamenti, riepilogo-pagamenti, risultati-di-ricerca, blog
+
+Note: suggerimenti + tono di voce exist only in the published build, not in repo master → harvest from docs.italia.it pages.
+
+### Open questions
+
+- Skill name: `scrivi-chiaro-pa`? alternatives: `linguaggio-pa`, `pa-scrivi-semplice`
+- Include social/newsletter + immagini/video + gestione contenuti in v1, or keep it lean (web/letters/notices only)?
+- Evals in the same PR or follow-up?
+
 ## Phase 1: Document & PRD
 - [x] Create PRD.md (English) with:
   - Project vision & goals


### PR DESCRIPTION
## What

New skill `scrivi-chiaro-pa`: write, rewrite, or review Italian PA content in plain language, applying the Designers Italia [Guida al linguaggio della Pubblica Amministrazione](https://docs.italia.it/italia/designers-italia/writing-toolkit/it/bozza/index.html) (CC-BY 4.0).

## Structure

- `SKILL.md` — 3 modes (draft / rewrite / review), workflow, core principles, final checklist
- `references/stile-di-scrittura.md` — style, verbs, acronyms, punctuation, numbers/dates, formatting
- `references/struttura-e-leggibilita.md` — content structure, UI microcopy, SEO, accessibility/inclusion
- `references/tono-di-voce.md` — 9 tone scenarios (user mood → PA approach, with original Italian examples)
- `references/canali-e-redazione.md` — social, newsletter, images/video, content management
- `references/glossario-parole-pa.md` — A–Z glossary in two tables (bureaucratese to replace + spelling/capitalization rules)

## Notes

- Instructions in English, examples and output in Italian (same convention as `difensore-civico-ti-scrivo`)
- Sources: published "bozza" build on docs.italia.it (suggerimenti + tono di voce exist only there) and `italia/writing-toolkit` repo master (glossary RST)
- Evals battery to follow in a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)